### PR TITLE
PR 1/6: Data foundation — migration 028 + TriageResult model

### DIFF
--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -62,6 +62,14 @@ class ResearchError(BaseModel):
     detail: str | None = None
 
 
+class TriageResult(BaseModel):
+    action: str = "research"               # "research" | "skip"
+    corrected_project: dict | None = None  # project dict with resolved name/developer
+    skip_reason: str | None = None         # machine-readable code
+    triage_log: list[dict] = []            # rules fired, tools called, findings
+    tokens_used: int = 0
+
+
 class AgentResult(BaseModel):
     epc_contractor: str | None = None
     confidence: str = "unknown"  # confirmed / likely / possible / unknown

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -63,7 +65,7 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"  # "research" | "skip"
+    action: Literal["research", "skip"] = "research"
     corrected_project: dict | None = None  # project dict with resolved name/developer
     skip_reason: str | None = None  # machine-readable code
     triage_log: list[dict] = []  # rules fired, tools called, findings

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -63,10 +63,10 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"               # "research" | "skip"
+    action: str = "research"  # "research" | "skip"
     corrected_project: dict | None = None  # project dict with resolved name/developer
-    skip_reason: str | None = None         # machine-readable code
-    triage_log: list[dict] = []            # rules fired, tools called, findings
+    skip_reason: str | None = None  # machine-readable code
+    triage_log: list[dict] = []  # rules fired, tools called, findings
     tokens_used: int = 0
 
 

--- a/supabase/migrations/028_add_triage_columns.sql
+++ b/supabase/migrations/028_add_triage_columns.sql
@@ -1,0 +1,14 @@
+-- Add triage-related columns to projects table
+-- These support the triage pre-check that classifies projects before research
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS name_type TEXT;
+-- Values: 'marketing' | 'poi' | 'description' | null
+-- Set by scraper on ingest; null for historical rows
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS interconnecting_utility TEXT;
+-- The grid utility at the point of interconnection
+-- Set by CAISO scraper (MISO/PJM put utility in developer field)
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS triage_result JSONB;
+-- Cached TriageResult from triage_project(). Includes triaged_at timestamp.
+-- Reused if < 30 days old. Re-triaged after expiry.


### PR DESCRIPTION
## Summary

Foundation PR for the timeout-salvage and triage-layer work. Pure additive, zero behavior change.

- Migration 028: adds `name_type`, `interconnecting_utility`, `triage_result` columns to `projects` table
- Adds `TriageResult` Pydantic model in `agent/src/models.py`

## Context

This is the first of 6 stacked PRs addressing the EPC research queue audit findings (~30 of 63 rows producing blank timeouts). See `docs/superpowers/specs/2026-04-14-triage-layer-v1-utility-poi.md` and `docs/superpowers/specs/2026-04-14-timeout-salvage-hardstop.md`.

## Merge order

**Must merge first.** Blocks: PR 4, PR 6.

| PR | Base | Dependency |
|----|------|-----------|
| **PR 1 (this)** | main | — |
| PR 2 | main | — |
| PR 3 | pr2/salvage-module | PR 2 |
| PR 4 | pr1/data-foundation | PR 1 |
| PR 6 | pr1/data-foundation | PR 1 |
| PR 5 | pr4/triage-module | PR 4 |

## Test plan

- [ ] Run migration 028 against Supabase staging
- [ ] Verify `TriageResult()` instantiates with defaults: `python -c "from agent.src.models import TriageResult; print(TriageResult())"`

## Plain English

Adds three new database columns and one new data type. Nothing uses them yet — that comes in later PRs. Safe to merge immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project triage result tracking: projects can be classified by type, record interconnection utility details, and cache triage outcomes with timestamps for better visibility and auditing.
  * Introduced a standardized triage result payload to capture triage decisions, optional corrected project data, triage logs, and usage metrics to improve consistency and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->