### PR TITLE
PR 3/6: HARD_STOP bug fix + salvage wiring

### DIFF
--- a/agent/src/research.py
+++ b/agent/src/research.py
@@ -28,6 +28,7 @@ from .completeness import CHECKPOINTS, evaluate_completeness
 from .models import AgentResult, ResearchError
 from .parsing import parse_report_findings
 from .prompts import PLANNING_SYSTEM_PROMPT, RESEARCH_SYSTEM_PROMPT, build_user_message
+from .salvage import synthesize_timeout_salvage
 from .tools import check_tool_health, execute_tool, get_tools
 
 MODEL = os.environ.get("RESEARCH_MODEL", "claude-sonnet-4-6")
@@ -126,6 +127,7 @@ async def run_research(
     recent_tool_outputs: list[dict] = []
     # Effective iteration counter — notify_progress-only turns don't count
     effective_iteration = 0
+    consecutive_status_only = 0
 
     for iteration in range(MAX_ITERATIONS):
         # Completeness checkpoint (Harvey AI pattern): at iterations 6, 12, 18
@@ -151,7 +153,7 @@ async def run_research(
         # to force the agent to conclude. The mandatory checkpoint at 18 is a
         # text nudge the agent can ignore; this is structural — it literally
         # cannot call anything else.
-        if effective_iteration >= HARD_STOP_ITERATION:
+        if effective_iteration >= HARD_STOP_ITERATION or iteration >= MAX_ITERATIONS - 3:
             active_tools = [t for t in cached_tools if t["name"] == "report_findings"]
             hard_stop_msg = (
                 "\n\nSYSTEM: You have exhausted your research budget. "
@@ -307,7 +309,13 @@ async def run_research(
         }
         substantive_tools = tool_names_this_turn - {"notify_progress", "research_scratchpad"}
         if substantive_tools:
+            consecutive_status_only = 0
             effective_iteration += 1
+        else:
+            consecutive_status_only += 1
+            if consecutive_status_only >= 3:
+                effective_iteration += 1
+                consecutive_status_only = 0
 
         # 3b: Check for consecutive tool errors — if 3+, tell agent to wrap up
         healthy, health_msg = check_tool_health(recent_tool_outputs)
@@ -326,13 +334,23 @@ async def run_research(
 
         # Context compaction is handled by the AgentRuntime in src/agents/research.py.
 
-    # 3c: Max iterations reached
+    # 3c: Max iterations reached — synthesize structured negative evidence
+    salvage = synthesize_timeout_salvage(agent_log, project, recent_tool_outputs)
     return (
         AgentResult(
-            reasoning="Research timed out after maximum iterations.",
+            reasoning={
+                "summary": salvage["summary"],
+                "supporting_evidence": salvage["supporting_evidence"],
+                "gaps": salvage["gaps"],
+            },
+            confidence="unknown",
+            epc_contractor=None,
+            sources=salvage["sources"],
+            searches_performed=salvage["queries_tried"],
+            negative_evidence=salvage["negative_evidence"],
             error=ResearchError(
-                category="max_iterations",
-                message="Research timed out after maximum iterations without completing.",
+                category="max_iterations_salvaged",
+                message="Hit iteration cap; salvaged structured negative evidence.",
             ),
         ),
         agent_log,

--- a/agent/src/salvage.py
+++ b/agent/src/salvage.py
@@ -1,0 +1,172 @@
+"""Deterministic extraction of structured negative evidence from timed-out research runs.
+
+When a research agent hits MAX_ITERATIONS without calling report_findings, this
+module extracts everything it learned from the agent_log and recent_tool_outputs.
+No LLM call. Pure dict traversal + regex matching. Cost: <50ms, 0 tokens.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .models import EpcSource, NegativeEvidence
+
+
+# Known EPC contractors for candidate detection in scratchpad notes
+KNOWN_EPCS = [
+    "McCarthy Building", "Mortenson", "Blattner", "Signal Energy", "SOLV Energy",
+    "Primoris", "Rosendin", "Strata Solar", "RES", "Renewable Energy Systems",
+    "NextEra", "Invenergy", "Array Technologies", "GameChange Solar",
+    "Swinerton", "Burns McDonnell", "Burns & McDonnell", "Quanta Services",
+    "MasTec", "Tetra Tech", "Black & Veatch", "Bechtel", "Fluor",
+    "SunPower", "First Solar", "Canadian Solar", "JinkoSolar",
+    "LONGi", "Trina Solar", "BayWa", "Enel", "Acciona", "Iberdrola",
+    "EDF Renewables", "TotalEnergies", "bp", "Shell", "Clearway",
+    "AES", "Duke Energy Renewables", "Avangrid", "Orsted",
+    "Leeward Renewable Energy", "Lightsource bp", "Silicon Ranch",
+    "Cypress Creek Renewables", "Scout Clean Energy", "Savion",
+    "174 Power Global", "D.E. Shaw Renewable Investments",
+]
+
+_ELIMINATION_RE = re.compile(
+    r"\b(ruled out|eliminated|not\b|no match|doesn't match|does not match|"
+    r"no evidence|couldn't find|could not find|unlikely|wrong|incorrect)\b",
+    re.IGNORECASE,
+)
+
+_OBSTACLE_RE = re.compile(
+    r"(dead end|stuck|cannot find|no public|pre-financial|early stage|"
+    r"not announced|no information|blocked|unable to)",
+    re.IGNORECASE,
+)
+
+
+def synthesize_timeout_salvage(
+    agent_log: list[dict],
+    project: dict,
+    recent_tool_outputs: list[dict],
+) -> dict:
+    """Extract structured negative evidence from a timed-out research run.
+
+    Returns dict with keys matching the spec: summary, queries_tried,
+    sources_consulted, candidate_names_considered, entities_eliminated,
+    self_identified_obstacles, next_recommended_action, supporting_evidence,
+    gaps, sources, negative_evidence.
+    """
+    queries_tried = [
+        e["input"]["query"]
+        for e in agent_log
+        if e.get("tool") in {"web_search", "web_search_broad"}
+    ]
+
+    sources_consulted = [
+        e["input"]["url"]
+        for e in agent_log
+        if e.get("tool") == "fetch_page"
+    ]
+
+    scratchpad_notes = [
+        e["input"]["note"]
+        for e in agent_log
+        if e.get("tool") == "research_scratchpad"
+    ]
+
+    # Detect candidate EPC names mentioned in scratchpad
+    all_scratchpad_text = " ".join(scratchpad_notes)
+    candidates_considered: list[str] = []
+    entities_eliminated: list[str] = []
+
+    for epc in KNOWN_EPCS:
+        if epc.lower() in all_scratchpad_text.lower():
+            candidates_considered.append(epc)
+            # Check if this EPC was explicitly eliminated
+            for note in scratchpad_notes:
+                if epc.lower() in note.lower() and _ELIMINATION_RE.search(note):
+                    entities_eliminated.append(epc)
+                    break
+
+    # Self-identified obstacles from scratchpad
+    obstacles = [note for note in scratchpad_notes if _OBSTACLE_RE.search(note)]
+
+    # Determine recommended next action
+    if obstacles and any(
+        "pre-financial" in o.lower()
+        or "early stage" in o.lower()
+        or "not announced" in o.lower()
+        for o in obstacles
+    ):
+        next_action = "defer"
+    elif len(queries_tried) < 5:
+        next_action = "triage_retry"
+    else:
+        next_action = "manual_review"
+
+    # Build human-readable summary
+    project_name = project.get("project_name", "Unknown")
+    parts = [
+        f"Research hit iteration cap without identifying EPC for {project_name}.",
+        f"Agent tried {len(queries_tried)} queries across {len(sources_consulted)} sources.",
+    ]
+    if candidates_considered:
+        parts.append(f"Candidate contractors considered: {', '.join(candidates_considered)}.")
+    if entities_eliminated:
+        parts.append(f"Explicitly eliminated: {', '.join(entities_eliminated)}.")
+    if obstacles:
+        parts.append(f'Primary obstacle identified by agent: "{obstacles[0][:200]}".')
+    parts.append(f"Recommended next step: {next_action}.")
+    summary = " ".join(parts)
+
+    # Supporting evidence: non-obstacle scratchpad notes
+    supporting_evidence = [
+        note[:500] for note in scratchpad_notes if not _OBSTACLE_RE.search(note)
+    ]
+
+    # Gaps: what was still missing
+    gaps: list[str] = []
+    if not candidates_considered:
+        gaps.append("No EPC candidates identified during research")
+    if not sources_consulted:
+        gaps.append("No web pages fetched during research")
+    for obs in obstacles[:3]:
+        gaps.append(obs[:300])
+
+    # Build EpcSource objects
+    epc_sources = [
+        EpcSource(
+            channel="web_search",
+            excerpt=f"Fetched during timeout research for {project_name}",
+            url=url,
+            reliability="low",
+        )
+        for url in sources_consulted[:10]
+    ]
+
+    # Build NegativeEvidence objects
+    neg_evidence = []
+    for epc in entities_eliminated:
+        # Find the most relevant query for this EPC
+        relevant_query = next(
+            (q for q in queries_tried if epc.lower().split()[0].lower() in q.lower()),
+            queries_tried[0] if queries_tried else f"search for {epc}",
+        )
+        neg_evidence.append(
+            NegativeEvidence(
+                search_query=relevant_query,
+                expected_to_find=epc,
+                what_was_found="nothing",
+            )
+        )
+
+    return {
+        "summary": summary,
+        "queries_tried": queries_tried,
+        "sources_consulted": sources_consulted,
+        "candidate_names_considered": candidates_considered,
+        "entities_eliminated": entities_eliminated,
+        "self_identified_obstacles": obstacles,
+        "next_recommended_action": next_action,
+        "supporting_evidence": supporting_evidence,
+        "gaps": gaps,
+        "sources": epc_sources,
+        "negative_evidence": neg_evidence,
+    }

--- a/agent/src/salvage.py
+++ b/agent/src/salvage.py
@@ -11,21 +11,58 @@ import re
 
 from .models import EpcSource, NegativeEvidence
 
-
 # Known EPC contractors for candidate detection in scratchpad notes
 KNOWN_EPCS = [
-    "McCarthy Building", "Mortenson", "Blattner", "Signal Energy", "SOLV Energy",
-    "Primoris", "Rosendin", "Strata Solar", "RES", "Renewable Energy Systems",
-    "NextEra", "Invenergy", "Array Technologies", "GameChange Solar",
-    "Swinerton", "Burns McDonnell", "Burns & McDonnell", "Quanta Services",
-    "MasTec", "Tetra Tech", "Black & Veatch", "Bechtel", "Fluor",
-    "SunPower", "First Solar", "Canadian Solar", "JinkoSolar",
-    "LONGi", "Trina Solar", "BayWa", "Enel", "Acciona", "Iberdrola",
-    "EDF Renewables", "TotalEnergies", "bp", "Shell", "Clearway",
-    "AES", "Duke Energy Renewables", "Avangrid", "Orsted",
-    "Leeward Renewable Energy", "Lightsource bp", "Silicon Ranch",
-    "Cypress Creek Renewables", "Scout Clean Energy", "Savion",
-    "174 Power Global", "D.E. Shaw Renewable Investments",
+    "McCarthy Building",
+    "Mortenson",
+    "Blattner",
+    "Signal Energy",
+    "SOLV Energy",
+    "Primoris",
+    "Rosendin",
+    "Strata Solar",
+    "RES",
+    "Renewable Energy Systems",
+    "NextEra",
+    "Invenergy",
+    "Array Technologies",
+    "GameChange Solar",
+    "Swinerton",
+    "Burns McDonnell",
+    "Burns & McDonnell",
+    "Quanta Services",
+    "MasTec",
+    "Tetra Tech",
+    "Black & Veatch",
+    "Bechtel",
+    "Fluor",
+    "SunPower",
+    "First Solar",
+    "Canadian Solar",
+    "JinkoSolar",
+    "LONGi",
+    "Trina Solar",
+    "BayWa",
+    "Enel",
+    "Acciona",
+    "Iberdrola",
+    "EDF Renewables",
+    "TotalEnergies",
+    "bp",
+    "Shell",
+    "Clearway",
+    "AES",
+    "Duke Energy Renewables",
+    "Avangrid",
+    "Orsted",
+    "Leeward Renewable Energy",
+    "Lightsource bp",
+    "Silicon Ranch",
+    "Cypress Creek Renewables",
+    "Scout Clean Energy",
+    "Savion",
+    "174 Power Global",
+    "D.E. Shaw Renewable Investments",
 ]
 
 _ELIMINATION_RE = re.compile(
@@ -59,16 +96,10 @@ def synthesize_timeout_salvage(
         if e.get("tool") in {"web_search", "web_search_broad"}
     ]
 
-    sources_consulted = [
-        e["input"]["url"]
-        for e in agent_log
-        if e.get("tool") == "fetch_page"
-    ]
+    sources_consulted = [e["input"]["url"] for e in agent_log if e.get("tool") == "fetch_page"]
 
     scratchpad_notes = [
-        e["input"]["note"]
-        for e in agent_log
-        if e.get("tool") == "research_scratchpad"
+        e["input"]["note"] for e in agent_log if e.get("tool") == "research_scratchpad"
     ]
 
     # Detect candidate EPC names mentioned in scratchpad
@@ -90,9 +121,7 @@ def synthesize_timeout_salvage(
 
     # Determine recommended next action
     if obstacles and any(
-        "pre-financial" in o.lower()
-        or "early stage" in o.lower()
-        or "not announced" in o.lower()
+        "pre-financial" in o.lower() or "early stage" in o.lower() or "not announced" in o.lower()
         for o in obstacles
     ):
         next_action = "defer"
@@ -117,9 +146,7 @@ def synthesize_timeout_salvage(
     summary = " ".join(parts)
 
     # Supporting evidence: non-obstacle scratchpad notes
-    supporting_evidence = [
-        note[:500] for note in scratchpad_notes if not _OBSTACLE_RE.search(note)
-    ]
+    supporting_evidence = [note[:500] for note in scratchpad_notes if not _OBSTACLE_RE.search(note)]
 
     # Gaps: what was still missing
     gaps: list[str] = []

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -270,9 +270,9 @@ class TestHardStopRawIteration:
         # At iteration 3 (MAX_ITERATIONS - 3 = 6 - 3 = 3), HARD_STOP should fire
         # So later iterations should only have report_findings available
         # The last few calls should have only report_findings in tools
-        assert any(
-            tools == ["report_findings"] for tools in tools_per_call
-        ), f"HARD_STOP never fired — tools per call: {tools_per_call}"
+        assert any(tools == ["report_findings"] for tools in tools_per_call), (
+            f"HARD_STOP never fired — tools per call: {tools_per_call}"
+        )
 
 
 class TestConsecutiveStatusOnly:
@@ -312,9 +312,9 @@ class TestConsecutiveStatusOnly:
         # After 3 consecutive status-only turns, effective_iteration increments
         # With HARD_STOP at 4, it should eventually engage even though
         # the agent only calls notify_progress
-        assert any(
-            tools == ["report_findings"] for tools in tools_per_call
-        ), "Status-only counter never triggered HARD_STOP"
+        assert any(tools == ["report_findings"] for tools in tools_per_call), (
+            "Status-only counter never triggered HARD_STOP"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -224,10 +224,97 @@ class TestMaxIterations:
 
         result, log, tokens = await run_research(sample_project)
 
-        assert "timed out" in result.reasoning.lower()
+        assert isinstance(result.reasoning, dict)
+        assert "summary" in result.reasoning
         assert result.error is not None
-        assert result.error.category == "max_iterations"
+        assert result.error.category == "max_iterations_salvaged"
         assert mock_client.messages.create.call_count == 2
+
+
+class TestHardStopRawIteration:
+    @patch("src.research.MAX_ITERATIONS", 6)
+    @patch("src.research.HARD_STOP_ITERATION", 100)  # disable effective_iteration trigger
+    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research.anthropic.AsyncAnthropic")
+    async def test_hard_stop_fires_on_raw_iteration(
+        self, MockClient, mock_exec_tool, sample_project
+    ):
+        """HARD_STOP should fire at MAX_ITERATIONS - 3 on raw iteration."""
+        # Agent only calls notify_progress — never increments effective_iteration
+        notify_block = make_tool_use_block(
+            name="notify_progress",
+            block_id="np-1",
+            input_data={"status": "still searching"},
+        )
+        resp = make_claude_response(
+            stop_reason="tool_use",
+            content=[notify_block],
+        )
+        mock_exec_tool.return_value = {"status": "ok"}
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+
+        # Track which tools are passed to each call
+        tools_per_call = []
+
+        async def capture_create(**kwargs):
+            tools_per_call.append([t["name"] for t in kwargs.get("tools", [])])
+            return resp
+
+        mock_client.messages.create = AsyncMock(side_effect=capture_create)
+        MockClient.return_value = mock_client
+
+        result, log, tokens = await run_research(sample_project)
+
+        # At iteration 3 (MAX_ITERATIONS - 3 = 6 - 3 = 3), HARD_STOP should fire
+        # So later iterations should only have report_findings available
+        # The last few calls should have only report_findings in tools
+        assert any(
+            tools == ["report_findings"] for tools in tools_per_call
+        ), f"HARD_STOP never fired — tools per call: {tools_per_call}"
+
+
+class TestConsecutiveStatusOnly:
+    @patch("src.research.MAX_ITERATIONS", 10)
+    @patch("src.research.HARD_STOP_ITERATION", 4)  # fires at effective_iteration 4
+    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research.anthropic.AsyncAnthropic")
+    async def test_consecutive_status_only_increments_effective(
+        self, MockClient, mock_exec_tool, sample_project
+    ):
+        """3 consecutive status-only turns should increment effective_iteration."""
+        notify_block = make_tool_use_block(
+            name="notify_progress",
+            block_id="np-1",
+            input_data={"status": "thinking"},
+        )
+        resp = make_claude_response(
+            stop_reason="tool_use",
+            content=[notify_block],
+        )
+        mock_exec_tool.return_value = {"status": "ok"}
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+
+        tools_per_call = []
+
+        async def capture_create(**kwargs):
+            tools_per_call.append([t["name"] for t in kwargs.get("tools", [])])
+            return resp
+
+        mock_client.messages.create = AsyncMock(side_effect=capture_create)
+        MockClient.return_value = mock_client
+
+        result, log, tokens = await run_research(sample_project)
+
+        # After 3 consecutive status-only turns, effective_iteration increments
+        # With HARD_STOP at 4, it should eventually engage even though
+        # the agent only calls notify_progress
+        assert any(
+            tools == ["report_findings"] for tools in tools_per_call
+        ), "Status-only counter never triggered HARD_STOP"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_salvage.py
+++ b/agent/tests/test_salvage.py
@@ -1,0 +1,170 @@
+"""Tests for the timeout salvage extraction module."""
+
+import pytest
+from src.salvage import synthesize_timeout_salvage
+from src.models import EpcSource, NegativeEvidence
+
+
+def _make_log(*entries):
+    """Build a minimal agent_log from tool call tuples."""
+    log = []
+    for entry in entries:
+        if isinstance(entry, tuple):
+            tool, input_data = entry
+            log.append({"tool": tool, "input": input_data})
+        else:
+            log.append(entry)
+    return log
+
+
+SAMPLE_PROJECT = {"project_name": "Honey Creek Solar", "state": "IN", "mw_capacity": 200}
+
+
+class TestExtractSearchQueries:
+    def test_extracts_search_queries(self):
+        """5 web_search entries -> queries_tried has 5 correct strings."""
+        log = _make_log(
+            ("web_search", {"query": "Honey Creek Solar EPC contractor"}),
+            ("web_search", {"query": "Honey Creek Solar Indiana construction"}),
+            ("web_search", {"query": "200MW solar Indiana EPC"}),
+            ("web_search", {"query": "Honey Creek Solar permit filing"}),
+            ("web_search", {"query": "Indiana solar farm construction company"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert len(result["queries_tried"]) == 5
+        assert result["queries_tried"][0] == "Honey Creek Solar EPC contractor"
+        assert result["queries_tried"][4] == "Indiana solar farm construction company"
+
+
+class TestExtractFetchUrls:
+    def test_extracts_fetch_urls(self):
+        """3 fetch_page entries -> sources_consulted has 3 URLs."""
+        log = _make_log(
+            ("fetch_page", {"url": "https://example.com/page1"}),
+            ("fetch_page", {"url": "https://solarnews.com/article"}),
+            ("fetch_page", {"url": "https://permits.in.gov/honey-creek"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert len(result["sources_consulted"]) == 3
+        assert "https://example.com/page1" in result["sources_consulted"]
+        assert "https://permits.in.gov/honey-creek" in result["sources_consulted"]
+
+
+class TestExtractScratchpadNotes:
+    def test_extracts_scratchpad_notes(self):
+        """2 research_scratchpad entries -> correctly extracted into processing."""
+        log = _make_log(
+            ("research_scratchpad", {"note": "Found mention of solar project in trade pub"}),
+            ("research_scratchpad", {"note": "Developer is SunDev LLC, checking their portfolio"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        # Notes are used for supporting_evidence (non-obstacle notes)
+        assert len(result["supporting_evidence"]) == 2
+        assert "Found mention of solar project" in result["supporting_evidence"][0]
+
+
+class TestCandidateDetection:
+    def test_candidate_detection_regex(self):
+        """Scratchpad mentions known EPCs -> both in candidates_considered."""
+        log = _make_log(
+            ("research_scratchpad", {"note": "Found McCarthy Building portfolio includes solar"}),
+            ("research_scratchpad", {"note": "Checking Blattner projects in Indiana region"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert "McCarthy Building" in result["candidate_names_considered"]
+        assert "Blattner" in result["candidate_names_considered"]
+
+
+class TestEntityElimination:
+    def test_entity_elimination(self):
+        """Scratchpad says 'Ruled out McCarthy Building' -> in entities_eliminated AND candidates."""
+        log = _make_log(
+            ("web_search", {"query": "McCarthy Building Indiana solar"}),
+            ("research_scratchpad", {"note": "Found McCarthy Building mentioned in Indiana permits"}),
+            ("research_scratchpad", {"note": "Ruled out McCarthy Building - no Indiana projects match"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert "McCarthy Building" in result["candidate_names_considered"]
+        assert "McCarthy Building" in result["entities_eliminated"]
+
+
+class TestEmptyAgentLog:
+    def test_empty_agent_log(self):
+        """Empty list, empty project -> valid dict, '0 queries' in summary."""
+        result = synthesize_timeout_salvage([], {}, [])
+        assert "0 queries" in result["summary"]
+        assert result["queries_tried"] == []
+        assert result["sources_consulted"] == []
+        assert result["candidate_names_considered"] == []
+        assert result["entities_eliminated"] == []
+        assert isinstance(result["summary"], str)
+
+
+class TestNoScratchpadUsed:
+    def test_no_scratchpad_used(self):
+        """Only web_search entries, no scratchpad -> candidates empty, queries populated."""
+        log = _make_log(
+            ("web_search", {"query": "Honey Creek Solar EPC"}),
+            ("web_search", {"query": "Honey Creek Solar contractor"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert len(result["queries_tried"]) == 2
+        assert result["candidate_names_considered"] == []
+        assert result["entities_eliminated"] == []
+        assert result["self_identified_obstacles"] == []
+
+
+class TestSummaryTextFormat:
+    def test_summary_text_format(self):
+        """Realistic log -> summary contains project name, query count, source count."""
+        log = _make_log(
+            ("web_search", {"query": "Honey Creek Solar EPC contractor"}),
+            ("web_search", {"query": "Honey Creek Solar Indiana construction"}),
+            ("web_search", {"query": "200MW solar Indiana EPC"}),
+            ("fetch_page", {"url": "https://example.com/article1"}),
+            ("fetch_page", {"url": "https://example.com/article2"}),
+            ("research_scratchpad", {"note": "Dead end on developer website, no EPC listed"}),
+            {"iteration": 0, "stop_reason": "tool_use", "input_tokens": 1234, "output_tokens": 567},
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert "Honey Creek Solar" in result["summary"]
+        assert "3 queries" in result["summary"]
+        assert "2 sources" in result["summary"]
+
+
+class TestStructuredReasoningShape:
+    def test_returns_structured_reasoning_shape(self):
+        """Verify dict has all required keys."""
+        result = synthesize_timeout_salvage([], SAMPLE_PROJECT, [])
+        required_keys = {
+            "summary",
+            "queries_tried",
+            "sources_consulted",
+            "candidate_names_considered",
+            "entities_eliminated",
+            "self_identified_obstacles",
+            "next_recommended_action",
+            "supporting_evidence",
+            "gaps",
+            "sources",
+            "negative_evidence",
+        }
+        assert required_keys == set(result.keys())
+
+
+class TestReturnsValidNegativeEvidence:
+    def test_returns_valid_negative_evidence(self):
+        """Log with eliminated EPC -> each item isinstance NegativeEvidence."""
+        log = _make_log(
+            ("web_search", {"query": "McCarthy Building Indiana solar projects"}),
+            ("web_search", {"query": "Blattner Energy Indiana EPC"}),
+            ("research_scratchpad", {"note": "Found McCarthy Building in search results"}),
+            ("research_scratchpad", {"note": "Ruled out McCarthy Building - wrong state, no evidence of Indiana work"}),
+            ("research_scratchpad", {"note": "Blattner mentioned but eliminated - not active in this region"}),
+        )
+        result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
+        assert len(result["negative_evidence"]) > 0
+        for item in result["negative_evidence"]:
+            assert isinstance(item, NegativeEvidence)
+            assert item.search_query  # non-empty
+            assert item.what_was_found == "nothing"

--- a/agent/tests/test_salvage.py
+++ b/agent/tests/test_salvage.py
@@ -1,8 +1,7 @@
 """Tests for the timeout salvage extraction module."""
 
-import pytest
+from src.models import NegativeEvidence
 from src.salvage import synthesize_timeout_salvage
-from src.models import EpcSource, NegativeEvidence
 
 
 def _make_log(*entries):
@@ -77,11 +76,17 @@ class TestCandidateDetection:
 
 class TestEntityElimination:
     def test_entity_elimination(self):
-        """Scratchpad says 'Ruled out McCarthy Building' -> in entities_eliminated AND candidates."""
+        """Ruled-out EPC appears in entities_eliminated AND candidates_considered."""
         log = _make_log(
             ("web_search", {"query": "McCarthy Building Indiana solar"}),
-            ("research_scratchpad", {"note": "Found McCarthy Building mentioned in Indiana permits"}),
-            ("research_scratchpad", {"note": "Ruled out McCarthy Building - no Indiana projects match"}),
+            (
+                "research_scratchpad",
+                {"note": "Found McCarthy Building mentioned in Indiana permits"},
+            ),
+            (
+                "research_scratchpad",
+                {"note": "Ruled out McCarthy Building - no Indiana projects match"},
+            ),
         )
         result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
         assert "McCarthy Building" in result["candidate_names_considered"]
@@ -159,8 +164,14 @@ class TestReturnsValidNegativeEvidence:
             ("web_search", {"query": "McCarthy Building Indiana solar projects"}),
             ("web_search", {"query": "Blattner Energy Indiana EPC"}),
             ("research_scratchpad", {"note": "Found McCarthy Building in search results"}),
-            ("research_scratchpad", {"note": "Ruled out McCarthy Building - wrong state, no evidence of Indiana work"}),
-            ("research_scratchpad", {"note": "Blattner mentioned but eliminated - not active in this region"}),
+            (
+                "research_scratchpad",
+                {"note": "Ruled out McCarthy Building - wrong state, no Indiana work"},
+            ),
+            (
+                "research_scratchpad",
+                {"note": "Blattner mentioned but eliminated - not active in region"},
+            ),
         )
         result = synthesize_timeout_salvage(log, SAMPLE_PROJECT, [])
         assert len(result["negative_evidence"]) > 0


### PR DESCRIPTION
## Summary

Three surgical changes to \`agent/src/research.py\` plus test updates. Makes timeout rows produce structured output instead of blank errors.

1. **HARD_STOP trigger fix** — now fires on raw iteration (\`MAX_ITERATIONS - 3\`) as backstop, closing the status-spam bypass
2. **consecutive_status_only counter** — 3 consecutive \`notify_progress\`/\`research_scratchpad\` turns now increment effective_iteration (counter resets after firing so legitimate status updates aren't penalized)
3. **Salvage wiring** — timeout branch at line 329 now calls \`synthesize_timeout_salvage()\` and returns structured reasoning dict

## Base

**Base: \`pr2/salvage-module\`** (stacked PR). Merge PR 2 first, then this PR's base will automatically flip to main.

## Test plan

- [x] 3/3 new tests passing (test_max_iterations, test_hard_stop_fires_on_raw_iteration, test_consecutive_status_only_increments_effective)
- [x] 10/10 salvage tests still passing (no regressions)
- [x] Existing test updated: \`test_max_iterations_returns_fallback\` now asserts structured reasoning dict and \`max_iterations_salvaged\` error category

## Plain English

Three bugs/improvements in the research loop. (1) The agent could previously dodge the "time's up" mechanism by spamming status updates that didn't count as real work — now there's a hard wall at iteration 22 regardless. (2) If the agent does nothing but status updates 3 times in a row, it now counts as real work so the clock still ticks. (3) When the agent runs out of time, instead of returning "I gave up," it now extracts whatever partial evidence it found and returns it in a structured format the frontend already knows how to display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)