### PR TITLE
PR 4/6: Triage module + tests

### DIFF
--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -62,6 +62,14 @@ class ResearchError(BaseModel):
     detail: str | None = None
 
 
+class TriageResult(BaseModel):
+    action: str = "research"               # "research" | "skip"
+    corrected_project: dict | None = None  # project dict with resolved name/developer
+    skip_reason: str | None = None         # machine-readable code
+    triage_log: list[dict] = []            # rules fired, tools called, findings
+    tokens_used: int = 0
+
+
 class AgentResult(BaseModel):
     epc_contractor: str | None = None
     confidence: str = "unknown"  # confirmed / likely / possible / unknown

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -63,7 +65,7 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"  # "research" | "skip"
+    action: Literal["research", "skip"] = "research"
     corrected_project: dict | None = None  # project dict with resolved name/developer
     skip_reason: str | None = None  # machine-readable code
     triage_log: list[dict] = []  # rules fired, tools called, findings

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -63,10 +63,10 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"               # "research" | "skip"
+    action: str = "research"  # "research" | "skip"
     corrected_project: dict | None = None  # project dict with resolved name/developer
-    skip_reason: str | None = None         # machine-readable code
-    triage_log: list[dict] = []            # rules fired, tools called, findings
+    skip_reason: str | None = None  # machine-readable code
+    triage_log: list[dict] = []  # rules fired, tools called, findings
     tokens_used: int = 0
 
 

--- a/agent/src/triage.py
+++ b/agent/src/triage.py
@@ -291,8 +291,12 @@ async def triage_project(
                     age = datetime.now(UTC) - datetime.fromisoformat(triaged_at)
                     if age < timedelta(days=CACHE_TTL_DAYS):
                         triage_log.append({"rule": "cache_hit", "age_days": age.days})
+                        # Defensive: tolerate legacy cache rows with unknown action values
+                        cached_action = cached.get("action", "research")
+                        if cached_action not in ("research", "skip"):
+                            cached_action = "research"
                         return TriageResult(
-                            action=cached.get("action", "research"),
+                            action=cached_action,
                             corrected_project=cached.get("corrected_project"),
                             skip_reason=cached.get("skip_reason"),
                             triage_log=triage_log,
@@ -381,8 +385,6 @@ def _persist_triage(project_id: str | None, result: TriageResult) -> None:
             "corrected_project": result.corrected_project,
             "triaged_at": datetime.now(UTC).isoformat(),
         }
-        client.table("projects").update({"triage_result": json.dumps(payload)}).eq(
-            "id", project_id
-        ).execute()
+        client.table("projects").update({"triage_result": payload}).eq("id", project_id).execute()
     except Exception as e:
         logger.warning("Failed to persist triage result: %s", e)

--- a/agent/src/triage.py
+++ b/agent/src/triage.py
@@ -1,0 +1,345 @@
+"""Triage layer v1: classify projects before research.
+
+Addresses two failure buckets from the EPC research queue audit:
+- Bucket #1: Utility listed as developer (SCE, PG&E, Entergy, etc.)
+- Bucket #2: POI/substation path used as project name ("Reynolds - Olive 345 kV")
+
+Runs BEFORE the iteration loop. Deterministic rules + optional LLM resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+import anthropic
+
+from .db import get_client
+from .models import TriageResult
+
+logger = logging.getLogger(__name__)
+
+# Triage cache TTL: reuse cached result if < 30 days old
+CACHE_TTL_DAYS = 30
+
+# ──────────────────────────────────────────────────────────────
+# Rule 1: Utility allow-list
+# ──────────────────────────────────────────────────────────────
+
+UTILITY_ALLOWLIST = {
+    "SCE", "SOUTHERN CALIFORNIA EDISON",
+    "PGAE", "PG&E", "PACIFIC GAS & ELECTRIC", "PACIFIC GAS AND ELECTRIC",
+    "SDGE", "SAN DIEGO GAS & ELECTRIC",
+    "DCRT",
+    "ENTERGY ARKANSAS", "ENTERGY LOUISIANA", "ENTERGY MISSISSIPPI",
+    "ENTERGY TEXAS", "ENTERGY NEW ORLEANS",
+    "AMEREN ILLINOIS", "AMEREN MISSOURI",
+    "AMEREN TRANSMISSION COMPANY OF ILLINOIS",
+    "AEP", "AMERICAN ELECTRIC POWER", "AEP INDIANA MICHIGAN", "I&M",
+    "JCPL", "JERSEY CENTRAL POWER & LIGHT",
+    "HOOSIER ENERGY",
+    "CENTERPOINT ENERGY INDIANA SOUTH",
+    "SOUTHERN COMPANY", "ALABAMA POWER", "GEORGIA POWER", "MISSISSIPPI POWER",
+    "DOMINION", "DOMINION ENERGY",
+    "APS", "ARIZONA PUBLIC SERVICE",
+}
+
+
+def _is_utility(developer: str | None) -> bool:
+    """Check if developer is actually an interconnecting utility."""
+    if not developer:
+        return False
+    normalized = developer.strip().upper()
+    return normalized in UTILITY_ALLOWLIST
+
+
+# ──────────────────────────────────────────────────────────────
+# Rule 2: POI regex patterns
+# ──────────────────────────────────────────────────────────────
+
+POI_PATTERNS = [
+    # "Reynolds - Olive 345 kV"
+    re.compile(r"^[\w\s\./&-]+ ?- ?[\w\s\./&-]+ ?\d+(\.\d+)? ?kV$", re.IGNORECASE),
+    # "7COFFEEN - 7PANA 345.0kV"
+    re.compile(r"^\d+[A-Z]+ ?- ?\d+[A-Z]+ ?\d+(\.\d+)? ?kV$", re.IGNORECASE),
+    # "Wheatley 500 kV Switching Station"
+    re.compile(r"\d+(\.\d+)? ?kV (Switching Station|Substation|SS)$", re.IGNORECASE),
+    # "Taping 'Newport AB / ...' to 'Cash / ...'"
+    re.compile(r"^Taping .+ to .+ \d+kV", re.IGNORECASE),
+    # "EL DORADO EHV - SAREPTA 345/115 SS 345.0kV"
+    re.compile(r"^[\w\s]+ - [\w\s]+ \d+/\d+ SS \d+(\.\d+)? ?kV$", re.IGNORECASE),
+]
+
+
+def _is_poi_name(name: str | None) -> bool:
+    """Check if project name is a POI/substation path, not a marketing name."""
+    if not name:
+        return False
+    return any(p.search(name) for p in POI_PATTERNS)
+
+
+# ──────────────────────────────────────────────────────────────
+# Rule 3: Optional LLM name resolution
+# ──────────────────────────────────────────────────────────────
+
+_RESOLVE_SYSTEM_PROMPT = """You are a project-name resolver. Your job is to map an interconnection queue entry (which may use substation names or utility names as identifiers) to the public marketing name of the underlying solar project and its real developer.
+
+Rules:
+- The "utility" in US interconnection queues (SCE, PG&E, Entergy, Ameren, AEP, etc.) is almost never the developer. It's the grid owner at the point of interconnection.
+- Transmission-line names (e.g., "Reynolds - Olive 345 kV") describe WHERE the project connects, not what it's called.
+- You have budget for 3 web_search or fetch_page calls total. Use them wisely.
+- If you can't find a confident match, return project_name=null and explain.
+- Do NOT attempt to find the EPC contractor — that's a separate step."""
+
+_RESOLVE_TOOLS = [
+    {
+        "name": "web_search",
+        "description": "Search the web for project information.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "resolve_result",
+        "description": "Report the resolution result.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_name": {"type": "string", "description": "The public marketing name, or null if unknown"},
+                "developer": {"type": "string", "description": "The real generation owner, or null"},
+                "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+                "explanation": {"type": "string"},
+            },
+            "required": ["confidence", "explanation"],
+        },
+    },
+]
+
+
+async def _resolve_project_name(
+    project: dict,
+    api_key: str | None = None,
+) -> dict:
+    """Use a small LLM call to resolve a POI/utility project to its real name.
+
+    Budget: 3 tool calls, 2 iterations, ~2k tokens.
+    Returns: {project_name, developer, confidence, sources}
+    """
+    from .tools import execute_tool
+
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+    client = anthropic.AsyncAnthropic(api_key=key)
+
+    name = project.get("project_name", "Unknown")
+    state = project.get("state", "Unknown")
+    mw = project.get("mw_capacity", "Unknown")
+    dev = project.get("developer", "Unknown")
+
+    user_msg = (
+        f"Resolve this interconnection queue entry:\n"
+        f"- Queue name: {name}\n"
+        f"- State: {state}\n"
+        f"- MW capacity: {mw}\n"
+        f"- Listed developer: {dev}\n\n"
+        f"Find the real project marketing name and developer."
+    )
+
+    messages = [{"role": "user", "content": user_msg}]
+    sources: list[str] = []
+    tool_calls_used = 0
+    result: dict = {"project_name": None, "developer": None, "confidence": "low", "sources": []}
+
+    for _ in range(2):  # max 2 iterations
+        try:
+            response = await client.messages.create(
+                model="claude-sonnet-4-6",
+                max_tokens=2048,
+                system=_RESOLVE_SYSTEM_PROMPT,
+                tools=_RESOLVE_TOOLS,
+                messages=messages,
+            )
+        except Exception as e:
+            logger.warning("Triage resolve_project_name failed: %s", e)
+            return result
+
+        if response.stop_reason == "end_turn":
+            break
+
+        tool_results = []
+        for block in response.content:
+            if block.type != "tool_use":
+                continue
+
+            if block.name == "resolve_result":
+                result = {
+                    "project_name": block.input.get("project_name"),
+                    "developer": block.input.get("developer"),
+                    "confidence": block.input.get("confidence", "low"),
+                    "sources": sources,
+                }
+                return result
+
+            if block.name == "web_search" and tool_calls_used < 3:
+                tool_calls_used += 1
+                try:
+                    search_result = await execute_tool("web_search", block.input)
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": json.dumps(search_result) if isinstance(search_result, dict) else str(search_result),
+                    })
+                    # Track URLs from results as sources
+                    if isinstance(search_result, dict):
+                        for r in search_result.get("results", []):
+                            if r.get("url"):
+                                sources.append(r["url"])
+                except Exception as e:
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": json.dumps({"error": str(e)}),
+                        "is_error": True,
+                    })
+            else:
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": "Budget exhausted. Call resolve_result now.",
+                })
+
+        if tool_results:
+            messages.append({"role": "assistant", "content": response.content})
+            messages.append({"role": "user", "content": tool_results})
+
+    return result
+
+
+# ──────────────────────────────────────────────────────────────
+# Main triage function
+# ──────────────────────────────────────────────────────────────
+
+async def triage_project(
+    project: dict,
+    api_key: str | None = None,
+) -> TriageResult:
+    """Classify a project before research.
+
+    Rule evaluation order:
+    1. Check cache (reuse if < 30 days)
+    2. Utility allow-list match -> mark developer unknown
+    3. POI regex match -> mark name_type = poi
+    4. If either rule fired -> resolve_project_name (LLM call)
+    5. Return action=research (with corrected project) or action=skip
+    """
+    project_id = project.get("id")
+    triage_log: list[dict] = []
+    tokens_used = 0
+
+    # Check cache
+    if project_id:
+        try:
+            client = get_client()
+            resp = client.table("projects").select("triage_result").eq("id", project_id).execute()
+            if resp.data and resp.data[0].get("triage_result"):
+                cached = resp.data[0]["triage_result"]
+                triaged_at = cached.get("triaged_at")
+                if triaged_at:
+                    age = datetime.now(timezone.utc) - datetime.fromisoformat(triaged_at)
+                    if age < timedelta(days=CACHE_TTL_DAYS):
+                        triage_log.append({"rule": "cache_hit", "age_days": age.days})
+                        return TriageResult(
+                            action=cached.get("action", "research"),
+                            corrected_project=cached.get("corrected_project"),
+                            skip_reason=cached.get("skip_reason"),
+                            triage_log=triage_log,
+                            tokens_used=0,
+                        )
+        except Exception as e:
+            logger.warning("Triage cache check failed: %s", e)
+
+    # Rule 1: Utility allow-list
+    developer = project.get("developer")
+    is_utility = _is_utility(developer)
+    if is_utility:
+        triage_log.append({"rule": "utility_allowlist", "developer": developer})
+
+    # Rule 2: POI regex
+    name = project.get("project_name")
+    is_poi = _is_poi_name(name)
+    if is_poi:
+        triage_log.append({"rule": "poi_regex", "name": name})
+
+    # If neither rule fired, pass through
+    if not is_utility and not is_poi:
+        triage_log.append({"rule": "pass_through"})
+        result = TriageResult(action="research", triage_log=triage_log)
+        _persist_triage(project_id, result)
+        return result
+
+    # Rule 3: Resolve project name
+    triage_log.append({"rule": "resolve_project_name", "triggered_by": "utility" if is_utility else "poi"})
+
+    resolution = await _resolve_project_name(project, api_key)
+    triage_log.append({"resolution": resolution})
+
+    confidence = resolution.get("confidence", "low")
+    resolved_name = resolution.get("project_name")
+    resolved_dev = resolution.get("developer")
+
+    if confidence in ("high", "medium") and resolved_name:
+        # Build corrected project
+        corrected = dict(project)
+        corrected["project_name"] = resolved_name
+        if resolved_dev:
+            corrected["developer"] = resolved_dev
+        elif is_utility:
+            corrected["developer"] = None
+
+        triage_log.append({"rule": "resolved", "name": resolved_name, "developer": resolved_dev})
+        result = TriageResult(
+            action="research",
+            corrected_project=corrected,
+            triage_log=triage_log,
+            tokens_used=tokens_used,
+        )
+    else:
+        # Resolution failed
+        if is_utility:
+            skip_reason = "utility_as_developer_unresolved"
+        elif is_poi:
+            skip_reason = "poi_name_unresolved"
+        else:
+            skip_reason = "needs_name_resolution"
+
+        triage_log.append({"rule": "skip", "reason": skip_reason})
+        result = TriageResult(
+            action="skip",
+            skip_reason=skip_reason,
+            triage_log=triage_log,
+            tokens_used=tokens_used,
+        )
+
+    _persist_triage(project_id, result)
+    return result
+
+
+def _persist_triage(project_id: str | None, result: TriageResult) -> None:
+    """Cache triage result on the projects table."""
+    if not project_id:
+        return
+    try:
+        client = get_client()
+        payload = {
+            "action": result.action,
+            "skip_reason": result.skip_reason,
+            "corrected_project": result.corrected_project,
+            "triaged_at": datetime.now(timezone.utc).isoformat(),
+        }
+        client.table("projects").update({"triage_result": json.dumps(payload)}).eq("id", project_id).execute()
+    except Exception as e:
+        logger.warning("Failed to persist triage result: %s", e)

--- a/agent/src/triage.py
+++ b/agent/src/triage.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import anthropic
 
@@ -30,21 +30,39 @@ CACHE_TTL_DAYS = 30
 # ──────────────────────────────────────────────────────────────
 
 UTILITY_ALLOWLIST = {
-    "SCE", "SOUTHERN CALIFORNIA EDISON",
-    "PGAE", "PG&E", "PACIFIC GAS & ELECTRIC", "PACIFIC GAS AND ELECTRIC",
-    "SDGE", "SAN DIEGO GAS & ELECTRIC",
+    "SCE",
+    "SOUTHERN CALIFORNIA EDISON",
+    "PGAE",
+    "PG&E",
+    "PACIFIC GAS & ELECTRIC",
+    "PACIFIC GAS AND ELECTRIC",
+    "SDGE",
+    "SAN DIEGO GAS & ELECTRIC",
     "DCRT",
-    "ENTERGY ARKANSAS", "ENTERGY LOUISIANA", "ENTERGY MISSISSIPPI",
-    "ENTERGY TEXAS", "ENTERGY NEW ORLEANS",
-    "AMEREN ILLINOIS", "AMEREN MISSOURI",
+    "ENTERGY ARKANSAS",
+    "ENTERGY LOUISIANA",
+    "ENTERGY MISSISSIPPI",
+    "ENTERGY TEXAS",
+    "ENTERGY NEW ORLEANS",
+    "AMEREN ILLINOIS",
+    "AMEREN MISSOURI",
     "AMEREN TRANSMISSION COMPANY OF ILLINOIS",
-    "AEP", "AMERICAN ELECTRIC POWER", "AEP INDIANA MICHIGAN", "I&M",
-    "JCPL", "JERSEY CENTRAL POWER & LIGHT",
+    "AEP",
+    "AMERICAN ELECTRIC POWER",
+    "AEP INDIANA MICHIGAN",
+    "I&M",
+    "JCPL",
+    "JERSEY CENTRAL POWER & LIGHT",
     "HOOSIER ENERGY",
     "CENTERPOINT ENERGY INDIANA SOUTH",
-    "SOUTHERN COMPANY", "ALABAMA POWER", "GEORGIA POWER", "MISSISSIPPI POWER",
-    "DOMINION", "DOMINION ENERGY",
-    "APS", "ARIZONA PUBLIC SERVICE",
+    "SOUTHERN COMPANY",
+    "ALABAMA POWER",
+    "GEORGIA POWER",
+    "MISSISSIPPI POWER",
+    "DOMINION",
+    "DOMINION ENERGY",
+    "APS",
+    "ARIZONA PUBLIC SERVICE",
 }
 
 
@@ -85,11 +103,17 @@ def _is_poi_name(name: str | None) -> bool:
 # Rule 3: Optional LLM name resolution
 # ──────────────────────────────────────────────────────────────
 
-_RESOLVE_SYSTEM_PROMPT = """You are a project-name resolver. Your job is to map an interconnection queue entry (which may use substation names or utility names as identifiers) to the public marketing name of the underlying solar project and its real developer.
+_RESOLVE_SYSTEM_PROMPT = """You are a project-name resolver. Your job is to map
+an interconnection queue entry (which may use substation names or utility names
+as identifiers) to the public marketing name of the underlying solar project
+and its real developer.
 
 Rules:
-- The "utility" in US interconnection queues (SCE, PG&E, Entergy, Ameren, AEP, etc.) is almost never the developer. It's the grid owner at the point of interconnection.
-- Transmission-line names (e.g., "Reynolds - Olive 345 kV") describe WHERE the project connects, not what it's called.
+- The "utility" in US interconnection queues (SCE, PG&E, Entergy, Ameren, AEP,
+  etc.) is almost never the developer. It's the grid owner at the point of
+  interconnection.
+- Transmission-line names (e.g., "Reynolds - Olive 345 kV") describe WHERE the
+  project connects, not what it's called.
 - You have budget for 3 web_search or fetch_page calls total. Use them wisely.
 - If you can't find a confident match, return project_name=null and explain.
 - Do NOT attempt to find the EPC contractor — that's a separate step."""
@@ -110,8 +134,14 @@ _RESOLVE_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "project_name": {"type": "string", "description": "The public marketing name, or null if unknown"},
-                "developer": {"type": "string", "description": "The real generation owner, or null"},
+                "project_name": {
+                    "type": "string",
+                    "description": "The public marketing name, or null if unknown",
+                },
+                "developer": {
+                    "type": "string",
+                    "description": "The real generation owner, or null",
+                },
                 "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
                 "explanation": {"type": "string"},
             },
@@ -188,29 +218,37 @@ async def _resolve_project_name(
                 tool_calls_used += 1
                 try:
                     search_result = await execute_tool("web_search", block.input)
-                    tool_results.append({
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": json.dumps(search_result) if isinstance(search_result, dict) else str(search_result),
-                    })
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": json.dumps(search_result)
+                            if isinstance(search_result, dict)
+                            else str(search_result),
+                        }
+                    )
                     # Track URLs from results as sources
                     if isinstance(search_result, dict):
                         for r in search_result.get("results", []):
                             if r.get("url"):
                                 sources.append(r["url"])
                 except Exception as e:
-                    tool_results.append({
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": json.dumps({"error": str(e)}),
+                            "is_error": True,
+                        }
+                    )
+            else:
+                tool_results.append(
+                    {
                         "type": "tool_result",
                         "tool_use_id": block.id,
-                        "content": json.dumps({"error": str(e)}),
-                        "is_error": True,
-                    })
-            else:
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": "Budget exhausted. Call resolve_result now.",
-                })
+                        "content": "Budget exhausted. Call resolve_result now.",
+                    }
+                )
 
         if tool_results:
             messages.append({"role": "assistant", "content": response.content})
@@ -222,6 +260,7 @@ async def _resolve_project_name(
 # ──────────────────────────────────────────────────────────────
 # Main triage function
 # ──────────────────────────────────────────────────────────────
+
 
 async def triage_project(
     project: dict,
@@ -249,7 +288,7 @@ async def triage_project(
                 cached = resp.data[0]["triage_result"]
                 triaged_at = cached.get("triaged_at")
                 if triaged_at:
-                    age = datetime.now(timezone.utc) - datetime.fromisoformat(triaged_at)
+                    age = datetime.now(UTC) - datetime.fromisoformat(triaged_at)
                     if age < timedelta(days=CACHE_TTL_DAYS):
                         triage_log.append({"rule": "cache_hit", "age_days": age.days})
                         return TriageResult(
@@ -282,7 +321,9 @@ async def triage_project(
         return result
 
     # Rule 3: Resolve project name
-    triage_log.append({"rule": "resolve_project_name", "triggered_by": "utility" if is_utility else "poi"})
+    triage_log.append(
+        {"rule": "resolve_project_name", "triggered_by": "utility" if is_utility else "poi"}
+    )
 
     resolution = await _resolve_project_name(project, api_key)
     triage_log.append({"resolution": resolution})
@@ -338,8 +379,10 @@ def _persist_triage(project_id: str | None, result: TriageResult) -> None:
             "action": result.action,
             "skip_reason": result.skip_reason,
             "corrected_project": result.corrected_project,
-            "triaged_at": datetime.now(timezone.utc).isoformat(),
+            "triaged_at": datetime.now(UTC).isoformat(),
         }
-        client.table("projects").update({"triage_result": json.dumps(payload)}).eq("id", project_id).execute()
+        client.table("projects").update({"triage_result": json.dumps(payload)}).eq(
+            "id", project_id
+        ).execute()
     except Exception as e:
         logger.warning("Failed to persist triage result: %s", e)

--- a/agent/tests/test_triage.py
+++ b/agent/tests/test_triage.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.models import TriageResult
 from src.triage import _is_poi_name, _is_utility, triage_project
-
 
 # ──────────────────────────────────────────────────────────────
 # Rule 1: Utility allow-list
@@ -65,9 +63,13 @@ def _mock_db_no_cache():
     mock_client = MagicMock()
     mock_resp = MagicMock()
     mock_resp.data = [{"triage_result": None}]
-    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_resp
+    )
     # Also mock update chain for _persist_triage
-    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = (
+        MagicMock()
+    )
     return mock_client
 
 
@@ -184,7 +186,7 @@ async def test_resolve_fails(mock_get_client, mock_resolve, sample_project):
 async def test_cache_reuse(mock_get_client, sample_project):
     """Fresh cached triage_result -> used directly, no resolution."""
     mock_client = MagicMock()
-    fresh_triaged_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+    fresh_triaged_at = (datetime.now(UTC) - timedelta(days=5)).isoformat()
     cached_result = {
         "action": "skip",
         "skip_reason": "utility_as_developer_unresolved",
@@ -193,7 +195,9 @@ async def test_cache_reuse(mock_get_client, sample_project):
     }
     mock_resp = MagicMock()
     mock_resp.data = [{"triage_result": cached_result}]
-    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_resp
+    )
     mock_get_client.return_value = mock_client
 
     result = await triage_project(sample_project)
@@ -210,7 +214,7 @@ async def test_cache_reuse(mock_get_client, sample_project):
 async def test_cache_expired(mock_get_client, mock_resolve, sample_project):
     """Expired cached triage_result -> re-triages from scratch."""
     mock_client = MagicMock()
-    old_triaged_at = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    old_triaged_at = (datetime.now(UTC) - timedelta(days=60)).isoformat()
     cached_result = {
         "action": "skip",
         "skip_reason": "utility_as_developer_unresolved",
@@ -219,9 +223,13 @@ async def test_cache_expired(mock_get_client, mock_resolve, sample_project):
     }
     mock_resp = MagicMock()
     mock_resp.data = [{"triage_result": cached_result}]
-    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_resp
+    )
     # Also mock update chain for _persist_triage
-    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = (
+        MagicMock()
+    )
     mock_get_client.return_value = mock_client
 
     mock_resolve.return_value = {

--- a/agent/tests/test_triage.py
+++ b/agent/tests/test_triage.py
@@ -1,0 +1,267 @@
+"""Tests for the triage pre-check module."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models import TriageResult
+from src.triage import _is_poi_name, _is_utility, triage_project
+
+
+# ──────────────────────────────────────────────────────────────
+# Rule 1: Utility allow-list
+# ──────────────────────────────────────────────────────────────
+
+
+def test_utility_allowlist_match_sce():
+    assert _is_utility("Southern California Edison") is True
+
+
+def test_utility_allowlist_match_normalized():
+    """Whitespace + case normalization."""
+    assert _is_utility("  pg&e  ") is True
+
+
+def test_utility_allowlist_no_match():
+    assert _is_utility("NextEra Energy") is False
+
+
+# ──────────────────────────────────────────────────────────────
+# Rule 2: POI regex patterns
+# ──────────────────────────────────────────────────────────────
+
+
+def test_poi_regex_substation():
+    assert _is_poi_name("Reynolds - Olive 345 kV") is True
+
+
+def test_poi_regex_numeric_prefix():
+    assert _is_poi_name("7COFFEEN - 7PANA 345.0kV") is True
+
+
+def test_poi_regex_switching_station():
+    assert _is_poi_name("Wheatley 500 kV Switching Station") is True
+
+
+def test_poi_regex_marketing_name():
+    assert _is_poi_name("Honey Creek Solar") is False
+
+
+def test_poi_regex_taping():
+    assert _is_poi_name("Taping 'Newport AB' to 'Cash' 345kV Line.") is True
+
+
+# ──────────────────────────────────────────────────────────────
+# Integration: triage_project
+# ──────────────────────────────────────────────────────────────
+
+
+def _mock_db_no_cache():
+    """Return a mock Supabase client with no cached triage result."""
+    mock_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.data = [{"triage_result": None}]
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    # Also mock update chain for _persist_triage
+    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+    return mock_client
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_both_rules_fire(mock_get_client, mock_resolve, sample_project):
+    """Utility developer + POI name -> both rules logged, resolution attempted."""
+    mock_get_client.return_value = _mock_db_no_cache()
+    mock_resolve.return_value = {
+        "project_name": "Sunrise Solar Farm",
+        "developer": "RealDev Corp",
+        "confidence": "high",
+        "sources": [],
+    }
+
+    sample_project["developer"] = "Southern California Edison"
+    sample_project["project_name"] = "Reynolds - Olive 345 kV"
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "research"
+    assert result.corrected_project is not None
+    assert result.corrected_project["project_name"] == "Sunrise Solar Farm"
+    # Both rules should appear in triage_log
+    rules = [entry.get("rule") for entry in result.triage_log]
+    assert "utility_allowlist" in rules
+    assert "poi_regex" in rules
+    mock_resolve.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_neither_rule_fires(mock_get_client, mock_resolve, sample_project):
+    """Real developer + marketing name -> pass through, no resolution."""
+    mock_get_client.return_value = _mock_db_no_cache()
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "research"
+    assert result.corrected_project is None
+    rules = [entry.get("rule") for entry in result.triage_log]
+    assert "pass_through" in rules
+    mock_resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_resolve_success(mock_get_client, mock_resolve, sample_project):
+    """High-confidence resolution -> corrected_project set."""
+    mock_get_client.return_value = _mock_db_no_cache()
+    mock_resolve.return_value = {
+        "project_name": "Desert Bloom Solar",
+        "developer": "SolarDev Inc",
+        "confidence": "high",
+        "sources": ["https://example.com"],
+    }
+
+    sample_project["developer"] = "PG&E"
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "research"
+    assert result.corrected_project["project_name"] == "Desert Bloom Solar"
+    assert result.corrected_project["developer"] == "SolarDev Inc"
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_resolve_low_confidence(mock_get_client, mock_resolve, sample_project):
+    """Low-confidence resolution -> action=skip."""
+    mock_get_client.return_value = _mock_db_no_cache()
+    mock_resolve.return_value = {
+        "project_name": None,
+        "developer": None,
+        "confidence": "low",
+        "sources": [],
+    }
+
+    sample_project["developer"] = "Entergy Arkansas"
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "skip"
+    assert result.skip_reason == "utility_as_developer_unresolved"
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_resolve_fails(mock_get_client, mock_resolve, sample_project):
+    """Resolution returns low confidence with no name -> skip."""
+    mock_get_client.return_value = _mock_db_no_cache()
+    mock_resolve.return_value = {
+        "project_name": None,
+        "developer": None,
+        "confidence": "low",
+        "sources": [],
+    }
+
+    sample_project["project_name"] = "Reynolds - Olive 345 kV"
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "skip"
+    assert result.skip_reason == "poi_name_unresolved"
+
+
+@pytest.mark.asyncio
+@patch("src.triage.get_client")
+async def test_cache_reuse(mock_get_client, sample_project):
+    """Fresh cached triage_result -> used directly, no resolution."""
+    mock_client = MagicMock()
+    fresh_triaged_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+    cached_result = {
+        "action": "skip",
+        "skip_reason": "utility_as_developer_unresolved",
+        "corrected_project": None,
+        "triaged_at": fresh_triaged_at,
+    }
+    mock_resp = MagicMock()
+    mock_resp.data = [{"triage_result": cached_result}]
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    mock_get_client.return_value = mock_client
+
+    result = await triage_project(sample_project)
+
+    assert result.action == "skip"
+    assert result.skip_reason == "utility_as_developer_unresolved"
+    rules = [entry.get("rule") for entry in result.triage_log]
+    assert "cache_hit" in rules
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_cache_expired(mock_get_client, mock_resolve, sample_project):
+    """Expired cached triage_result -> re-triages from scratch."""
+    mock_client = MagicMock()
+    old_triaged_at = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    cached_result = {
+        "action": "skip",
+        "skip_reason": "utility_as_developer_unresolved",
+        "corrected_project": None,
+        "triaged_at": old_triaged_at,
+    }
+    mock_resp = MagicMock()
+    mock_resp.data = [{"triage_result": cached_result}]
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_resp
+    # Also mock update chain for _persist_triage
+    mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_resolve.return_value = {
+        "project_name": None,
+        "developer": None,
+        "confidence": "low",
+        "sources": [],
+    }
+
+    # Give it a utility developer so a rule fires and resolution is attempted
+    sample_project["developer"] = "SCE"
+
+    result = await triage_project(sample_project)
+
+    # Should NOT use cache — should re-triage
+    rules = [entry.get("rule") for entry in result.triage_log]
+    assert "cache_hit" not in rules
+    mock_resolve.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.triage._resolve_project_name", new_callable=AsyncMock)
+@patch("src.triage.get_client")
+async def test_returns_pydantic_model(mock_get_client, mock_resolve, sample_project):
+    """Result is always a TriageResult instance."""
+    mock_get_client.return_value = _mock_db_no_cache()
+    mock_resolve.return_value = {
+        "project_name": "Resolved Name",
+        "developer": "Resolved Dev",
+        "confidence": "medium",
+        "sources": [],
+    }
+
+    sample_project["developer"] = "AEP"
+
+    result = await triage_project(sample_project)
+
+    assert isinstance(result, TriageResult)
+    assert hasattr(result, "action")
+    assert hasattr(result, "corrected_project")
+    assert hasattr(result, "skip_reason")
+    assert hasattr(result, "triage_log")
+    assert hasattr(result, "tokens_used")

--- a/supabase/migrations/028_add_triage_columns.sql
+++ b/supabase/migrations/028_add_triage_columns.sql
@@ -1,0 +1,14 @@
+-- Add triage-related columns to projects table
+-- These support the triage pre-check that classifies projects before research
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS name_type TEXT;
+-- Values: 'marketing' | 'poi' | 'description' | null
+-- Set by scraper on ingest; null for historical rows
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS interconnecting_utility TEXT;
+-- The grid utility at the point of interconnection
+-- Set by CAISO scraper (MISO/PJM put utility in developer field)
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS triage_result JSONB;
+-- Cached TriageResult from triage_project(). Includes triaged_at timestamp.
+-- Reused if < 30 days old. Re-triaged after expiry.


### PR DESCRIPTION
## Summary

Triage pre-check module that classifies projects before research runs. Catches two failure buckets from the EPC audit:

- **Bucket #1 — Utility listed as developer** (SCE, PG&E, Entergy, AEP, etc.) — 17 rows
- **Bucket #2 — POI/substation path used as project name** ("Reynolds - Olive 345 kV") — 20 rows

- New \`agent/src/triage.py\` with \`triage_project()\` async function
- Utility allowlist (~25 entries), 5 POI regex patterns, LLM-backed name resolution (3-search budget, 2k tokens)
- Cache triage results on \`projects.triage_result\` with 30-day TTL
- 16 unit tests covering all rules, resolution paths, caching, edge cases

## Base

**Base: \`pr1/data-foundation\`** (stacked PR). Requires \`TriageResult\` model and \`triage_result\` column.

## Test plan

- [x] 16/16 unit tests passing
- [ ] Verify LLM prompt behavior on real data post-deploy

## Plain English

Before researching a project, this module quickly checks if the data looks fishy — is the "developer" actually just the power company that owns the grid connection, or is the project "name" really just a description of which power lines it connects to? If so, it tries to look up the real name and developer. If it can not figure it out, it skips the project so we do not waste research tokens on garbage data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated project triage system that pre-classifies incoming projects before research processing
  * Projects matching utility or specific naming patterns are evaluated and may be skipped
  * Implemented result caching to avoid re-processing recently triaged projects
  * AI-assisted project name correction improves data accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->