### PR TITLE
PR 6/6: Scraper transform — utility detection + POI classification

### DIFF
--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -62,6 +62,14 @@ class ResearchError(BaseModel):
     detail: str | None = None
 
 
+class TriageResult(BaseModel):
+    action: str = "research"               # "research" | "skip"
+    corrected_project: dict | None = None  # project dict with resolved name/developer
+    skip_reason: str | None = None         # machine-readable code
+    triage_log: list[dict] = []            # rules fired, tools called, findings
+    tokens_used: int = 0
+
+
 class AgentResult(BaseModel):
     epc_contractor: str | None = None
     confidence: str = "unknown"  # confirmed / likely / possible / unknown

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -63,7 +65,7 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"  # "research" | "skip"
+    action: Literal["research", "skip"] = "research"
     corrected_project: dict | None = None  # project dict with resolved name/developer
     skip_reason: str | None = None  # machine-readable code
     triage_log: list[dict] = []  # rules fired, tools called, findings

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -63,10 +63,10 @@ class ResearchError(BaseModel):
 
 
 class TriageResult(BaseModel):
-    action: str = "research"               # "research" | "skip"
+    action: str = "research"  # "research" | "skip"
     corrected_project: dict | None = None  # project dict with resolved name/developer
-    skip_reason: str | None = None         # machine-readable code
-    triage_log: list[dict] = []            # rules fired, tools called, findings
+    skip_reason: str | None = None  # machine-readable code
+    triage_log: list[dict] = []  # rules fired, tools called, findings
     tokens_used: int = 0
 
 

--- a/scrapers/src/transform.py
+++ b/scrapers/src/transform.py
@@ -1,4 +1,50 @@
+import re
+
 import pandas as pd
+
+# Utility allow-list — matches triage module's list
+_UTILITY_NAMES = {
+    "SCE", "SOUTHERN CALIFORNIA EDISON",
+    "PGAE", "PG&E", "PACIFIC GAS & ELECTRIC", "PACIFIC GAS AND ELECTRIC",
+    "SDGE", "SAN DIEGO GAS & ELECTRIC",
+    "DCRT",
+    "ENTERGY ARKANSAS", "ENTERGY LOUISIANA", "ENTERGY MISSISSIPPI",
+    "ENTERGY TEXAS", "ENTERGY NEW ORLEANS",
+    "AMEREN ILLINOIS", "AMEREN MISSOURI",
+    "AMEREN TRANSMISSION COMPANY OF ILLINOIS",
+    "AEP", "AMERICAN ELECTRIC POWER", "AEP INDIANA MICHIGAN", "I&M",
+    "JCPL", "JERSEY CENTRAL POWER & LIGHT",
+    "HOOSIER ENERGY",
+    "CENTERPOINT ENERGY INDIANA SOUTH",
+    "SOUTHERN COMPANY", "ALABAMA POWER", "GEORGIA POWER", "MISSISSIPPI POWER",
+    "DOMINION", "DOMINION ENERGY",
+    "APS", "ARIZONA PUBLIC SERVICE",
+}
+
+# POI regex patterns — matches triage module's patterns
+_POI_PATTERNS = [
+    re.compile(r"^[\w\s\./&-]+ ?- ?[\w\s\./&-]+ ?\d+(\.\d+)? ?kV$", re.IGNORECASE),
+    re.compile(r"^\d+[A-Z]+ ?- ?\d+[A-Z]+ ?\d+(\.\d+)? ?kV$", re.IGNORECASE),
+    re.compile(r"\d+(\.\d+)? ?kV (Switching Station|Substation|SS)$", re.IGNORECASE),
+    re.compile(r"^Taping .+ to .+ \d+kV", re.IGNORECASE),
+    re.compile(r"^[\w\s]+ - [\w\s]+ \d+/\d+ SS \d+(\.\d+)? ?kV$", re.IGNORECASE),
+]
+
+
+def _classify_name(name: str | None) -> str:
+    """Classify project name as 'poi' or 'marketing'."""
+    if not name:
+        return "marketing"
+    return "poi" if any(p.search(name) for p in _POI_PATTERNS) else "marketing"
+
+
+def _detect_utility(developer: str | None) -> str | None:
+    """Return the developer string if it's a known utility, else None."""
+    if not developer:
+        return None
+    normalized = developer.strip().upper()
+    return developer if normalized in _UTILITY_NAMES else None
+
 
 # Target DB columns (excluding auto-generated ones)
 DB_COLUMNS = [
@@ -19,6 +65,8 @@ DB_COLUMNS = [
     "lead_score",
     "construction_status",
     "geocode_source",
+    "interconnecting_utility",
+    "name_type",
     "raw_data",
 ]
 
@@ -40,7 +88,7 @@ def transform_miso(raw: list[dict]) -> pd.DataFrame:
     """Transform raw MISO API records to DB schema."""
     rows = []
     for r in raw:
-        rows.append({
+        row = {
             "queue_id": r.get("projectNumber", ""),
             "iso_region": "MISO",
             "project_name": r.get("poiName") or None,
@@ -56,7 +104,9 @@ def transform_miso(raw: list[dict]) -> pd.DataFrame:
             "status": r.get("applicationStatus") or None,
             "source": "iso_queue",
             "raw_data": r,
-        })
+        }
+        row["name_type"] = _classify_name(row.get("project_name"))
+        rows.append(row)
     return pd.DataFrame(rows)
 
 
@@ -98,7 +148,7 @@ def transform_ercot(df_raw: pd.DataFrame) -> pd.DataFrame:
 
         raw = {k: (str(v) if pd.notna(v) else None) for k, v in r.items() if k is not None and str(k) != "nan"}
 
-        rows.append({
+        row = {
             "queue_id": str(r.get("INR", "")).strip(),
             "iso_region": "ERCOT",
             "project_name": str(r.get("Project Name", "")).strip() or None,
@@ -114,7 +164,9 @@ def transform_ercot(df_raw: pd.DataFrame) -> pd.DataFrame:
             "status": status,
             "source": "iso_queue",
             "raw_data": raw,
-        })
+        }
+        row["name_type"] = _classify_name(row.get("project_name"))
+        rows.append(row)
     return pd.DataFrame(rows)
 
 
@@ -145,7 +197,7 @@ def transform_caiso(sheets: dict[str, pd.DataFrame]) -> pd.DataFrame:
 
             raw = {k: (str(v) if pd.notna(v) else None) for k, v in r.items() if str(k) != "nan"}
 
-            all_rows.append({
+            row = {
                 "queue_id": str(r.get("Queue Position", "")).strip(),
                 "iso_region": "CAISO",
                 "project_name": str(project_name).strip() if pd.notna(project_name) else None,
@@ -161,7 +213,15 @@ def transform_caiso(sheets: dict[str, pd.DataFrame]) -> pd.DataFrame:
                 "status": str(r.get("Application Status", sheet_status)).strip() if pd.notna(r.get("Application Status")) else sheet_status,
                 "source": "iso_queue",
                 "raw_data": raw,
-            })
+            }
+            # Detect utility-as-developer
+            utility = _detect_utility(row.get("developer"))
+            if utility:
+                row["interconnecting_utility"] = utility
+                row["developer"] = None
+            # Classify project name
+            row["name_type"] = _classify_name(row.get("project_name"))
+            all_rows.append(row)
     return pd.DataFrame(all_rows)
 
 
@@ -183,7 +243,7 @@ def transform_pjm(df_raw: pd.DataFrame) -> pd.DataFrame:
 
         raw = {k: (str(v) if pd.notna(v) else None) for k, v in r.items() if k is not None and str(k) != "nan"}
 
-        rows.append({
+        row = {
             "queue_id": str(r.get("Project ID", "")).strip(),
             "iso_region": "PJM",
             "project_name": str(r.get("Name", "")).strip() or None,
@@ -199,7 +259,9 @@ def transform_pjm(df_raw: pd.DataFrame) -> pd.DataFrame:
             "status": str(r.get("Status", "")).strip() if pd.notna(r.get("Status")) else None,
             "source": "iso_queue",
             "raw_data": raw,
-        })
+        }
+        row["name_type"] = _classify_name(row.get("project_name"))
+        rows.append(row)
     return pd.DataFrame(rows)
 
 

--- a/supabase/migrations/028_add_triage_columns.sql
+++ b/supabase/migrations/028_add_triage_columns.sql
@@ -1,0 +1,14 @@
+-- Add triage-related columns to projects table
+-- These support the triage pre-check that classifies projects before research
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS name_type TEXT;
+-- Values: 'marketing' | 'poi' | 'description' | null
+-- Set by scraper on ingest; null for historical rows
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS interconnecting_utility TEXT;
+-- The grid utility at the point of interconnection
+-- Set by CAISO scraper (MISO/PJM put utility in developer field)
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS triage_result JSONB;
+-- Cached TriageResult from triage_project(). Includes triaged_at timestamp.
+-- Reused if < 30 days old. Re-triaged after expiry.


### PR DESCRIPTION
## Summary

Update scraper transform functions to populate new columns on ingest. Future rows come pre-classified; legacy rows handled at runtime by triage module.

- \`transform_caiso()\`: detects utility-as-developer, moves to \`interconnecting_utility\`, clears \`developer\`
- All transforms (CAISO, MISO, ERCOT, PJM): classify \`project_name\` as \`poi\` or \`marketing\` via regex
- Adds \`interconnecting_utility\` and \`name_type\` to \`DB_COLUMNS\` list

## Base

**Base: \`pr1/data-foundation\`** (stacked PR). Requires new columns from migration 028.

## Test plan

- [x] Manual verification: \`_classify_name("Reynolds - Olive 345 kV")\` → "poi"; \`_classify_name("Honey Creek Solar")\` → "marketing"
- [x] \`_detect_utility("Southern California Edison")\` returns the string; \`_detect_utility("NextEra Energy")\` returns None
- [ ] Monitor next scrape run to confirm \`name_type\` populated correctly

## Plain English

When the scrapers pull fresh data from ISO queues, they now tag each project with (a) whether the name is a real marketing name or just a power-line description, and (b) if the CAISO "developer" is actually the utility, move it to a separate column. This means going forward, the triage module's cache gets pre-populated for free at ingest time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)