### PR TITLE
PR 1/6: Add Finding and ReflectionResult data models for research v2

### DIFF
--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -54,6 +54,25 @@ class NegativeEvidence(BaseModel):
     what_was_found: str  # "nothing", "contradictory", "different_epc", "different_project"
 
 
+class Finding(BaseModel):
+    """A single piece of evidence collected during research."""
+
+    text: str
+    source_url: str
+    source_tool: str  # tavily_search, brave_search, sec_edgar, osha_inspection, etc.
+    reliability: str = "medium"  # high / medium / low
+    iteration: int = 0
+
+
+class ReflectionResult(BaseModel):
+    """Output of the analyze_and_plan reflection step."""
+
+    summary: str
+    gaps: list[str] = []
+    should_continue: bool = True
+    next_search_topic: str | None = None
+
+
 class ResearchError(BaseModel):
     # "api_key_missing" | "anthropic_error" | "search_tool_error"
     # | "max_iterations" | "no_report" | "db_error" | "unknown"

--- a/agent/tests/test_research_v2_models.py
+++ b/agent/tests/test_research_v2_models.py
@@ -1,0 +1,78 @@
+"""Tests for Finding and ReflectionResult models (research v2)."""
+
+from src.models import Finding, ReflectionResult
+
+
+class TestFinding:
+    def test_creation(self):
+        f = Finding(
+            text="McCarthy Building Companies selected as EPC for 200MW project",
+            source_url="https://example.com/article",
+            source_tool="tavily_search",
+            reliability="high",
+            iteration=1,
+        )
+        assert f.text.startswith("McCarthy")
+        assert f.source_tool == "tavily_search"
+        assert f.reliability == "high"
+        assert f.iteration == 1
+
+    def test_defaults(self):
+        f = Finding(
+            text="some info",
+            source_url="https://x.com",
+            source_tool="web_search",
+        )
+        assert f.reliability == "medium"
+        assert f.iteration == 0
+
+    def test_serialization_roundtrip(self):
+        f = Finding(
+            text="OSHA record at site",
+            source_url="https://osha.gov/record/123",
+            source_tool="osha_inspection",
+            reliability="high",
+            iteration=3,
+        )
+        data = f.model_dump()
+        f2 = Finding(**data)
+        assert f2 == f
+
+
+class TestReflectionResult:
+    def test_creation(self):
+        r = ReflectionResult(
+            summary="Found McCarthy as likely EPC from press release",
+            gaps=["No second independent source", "Need to verify scale"],
+            should_continue=True,
+            next_search_topic="McCarthy Building Companies solar portfolio MW",
+        )
+        assert r.should_continue is True
+        assert len(r.gaps) == 2
+        assert r.next_search_topic.startswith("McCarthy")
+
+    def test_stop_condition(self):
+        r = ReflectionResult(
+            summary="Confirmed EPC with 2 independent sources",
+            gaps=[],
+            should_continue=False,
+        )
+        assert r.should_continue is False
+        assert r.next_search_topic is None
+
+    def test_defaults(self):
+        r = ReflectionResult(summary="Minimal result")
+        assert r.gaps == []
+        assert r.should_continue is True
+        assert r.next_search_topic is None
+
+    def test_serialization_roundtrip(self):
+        r = ReflectionResult(
+            summary="test",
+            gaps=["gap1"],
+            should_continue=True,
+            next_search_topic="next query",
+        )
+        data = r.model_dump()
+        r2 = ReflectionResult(**data)
+        assert r2 == r


### PR DESCRIPTION
## Summary
- Add `Finding` Pydantic model: structured evidence with `text`, `source_url`, `source_tool`, `reliability`, `iteration`
- Add `ReflectionResult` Pydantic model: output of the gap-analysis step with `summary`, `gaps`, `should_continue`, `next_search_topic`
- Pure foundation for the research v2 loop — nothing references these yet

## Context
First in a stack of 6 PRs implementing a gap-driven research loop inspired by Open Deep Research and GPT-Researcher. See `docs/superpowers/plans/2026-04-14-deep-research-v2-pr-strategy.md` for the full plan.

PRs 1–4 are additive dead code. PR 5 swaps the implementation. PR 6 adds batch enhancement.

## Test plan
- [x] 7 new model tests pass (`test_research_v2_models.py`)
- [x] Full suite: 635 passed, 1 skipped, 0 regressions
- [ ] Reviewer confirms model shapes match the design doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)