### PR TITLE
PR 5/6: Wire run_research to v2 gap-driven loop

### DIFF
--- a/agent/src/prompts.py
+++ b/agent/src/prompts.py
@@ -175,31 +175,43 @@ identify and verify the EPC contractor.
 
 ## Research Process
 
-### Phase 1: Plan
-1. Call notify_progress(stage="planning", message="Reviewing project and building plan").
-2. Review project details and knowledge base context. Note what's already known \
-and what searches have been tried in prior research attempts.
-3. Formulate a research plan: list 3-5 high-level search strategies and why each \
-is relevant to this project. Consider:
-   - What the KB already tells us about this developer/state
-   - Which EPC portfolio sites to check based on developer and region
-   - Whether the project stage suggests an EPC has been selected yet
-   - Any challenges (shell company developer, early-stage project, etc.)
-4. Call notify_progress(stage="planning", message="Research plan: [brief summary]").
+You operate in a structured research loop. Each round:
+1. You call search tools to investigate the current research focus
+2. Between rounds, the system evaluates your evidence and identifies gaps
+3. You receive `[Research guidance: ...]` messages with a summary of findings, \
+remaining gaps, and a suggested next search focus
+4. You follow that guidance until the system tells you to wrap up
 
-### Phase 2: Execute
-5. Execute planned searches. Call notify_progress(stage="searching") after each.
-6. Follow promising leads with fetch_page. Call notify_progress(stage="reading").
-7. After completing the plan, assess: did I find enough evidence?
-8. If not, formulate 1-2 additional targeted searches.
-9. If an unexpected lead appears, follow it even if not in the original plan. \
-Call notify_progress(stage="switching_strategy") when deviating.
+### Round 1 — Broad initial search
+- Review project details and knowledge base context
+- Run 2-3 searches across different angles:
+  * Web search (Tavily): developer + project + "EPC" or "contractor"
+  * Industry rankings: search_wiki_solar, search_spw for scale verification
+  * Structured data: search_sec_edgar if developer is public, search_osha for construction records
+- Call notify_progress(stage="searching") after each so the UI reflects activity
 
-### Phase 3: Report
-10. Verify any candidate EPC before reporting (scale, specificity, role, counter-evidence).
-11. Call report_findings with your verified result. Every source MUST have a URL. \
-Log ALL searches performed.
-12. ALWAYS call report_findings, even if you found nothing (set confidence to 'unknown').
+### Round 2+ — Gap-driven refinement
+- You will receive guidance messages between rounds. They look like:
+  `[Research guidance: <summary>. Gaps remaining: <gaps>. Next search focus: <topic>. \
+Evidence so far: <numbered list>]`
+- Follow the suggested next_search_topic — it targets the biggest gap
+- Use fetch_page for promising leads; use web_search_broad (Brave) if Tavily misses
+- If the guidance says "call report_findings now" — do so immediately
+
+### Verification before reporting
+When you have a candidate EPC, verify:
+1. Scale check: search_wiki_solar or search_spw — is this company utility-scale capable?
+2. Project specificity: does your source name THIS project, not a similarly named one?
+3. Role check: is this company the EPC, or developer/utility/supplier?
+4. Counter-evidence: run at least 1 search trying to disprove your finding
+5. Source independence: prefer 2+ different channels (press release + portfolio + ranking)
+
+### Reporting
+- Call report_findings with your verified result
+- Every source MUST have a URL (or `search:<query>` if found in a snippet without direct link)
+- Log ALL searches performed, including dead ends
+- Include negative_evidence for searches that found nothing or contradictory info
+- Report "unknown" with clear reasoning if evidence is insufficient — better than guessing
 """
 
 # ---------------------------------------------------------------------------

--- a/agent/src/research.py
+++ b/agent/src/research.py
@@ -7,6 +7,10 @@ Used by:
 This is NOT a separate agent — it uses the same shared tools as the chat
 agent, but with a focused research-only system prompt and no conversation
 context. Think of it as "chat agent in research mode, headless."
+
+The research loop itself lives in research_loop.py (gap-driven v2 loop).
+This module exposes the public run_research() API plus the planning-only
+run_research_plan() variant.
 """
 
 from __future__ import annotations
@@ -14,7 +18,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from uuid import uuid4
 
 import anthropic
 from tenacity import (
@@ -24,34 +27,15 @@ from tenacity import (
     wait_exponential,
 )
 
-from .completeness import CHECKPOINTS, evaluate_completeness
-from .models import AgentResult, ResearchError
-from .parsing import parse_report_findings
-from .prompts import PLANNING_SYSTEM_PROMPT, RESEARCH_SYSTEM_PROMPT, build_user_message
-from .tools import check_tool_health, execute_tool, get_tools
+from .models import AgentResult
+from .prompts import PLANNING_SYSTEM_PROMPT, build_user_message
+from .research_loop import RESEARCH_TOOLS, run_research_loop
+from .tools import execute_tool, get_tools
+
+# Re-export RESEARCH_TOOLS so consumers importing from src.research continue to work
+__all__ = ["run_research", "run_research_plan", "RESEARCH_TOOLS", "PLANNING_TOOLS", "MODEL"]
 
 MODEL = os.environ.get("RESEARCH_MODEL", "claude-sonnet-4-6")
-MAX_ITERATIONS = 25
-# At this iteration, strip all tools except report_findings to force conclusion
-HARD_STOP_ITERATION = 22
-
-# Tools available during standalone research
-RESEARCH_TOOLS = [
-    "web_search",
-    "web_search_broad",
-    "fetch_page",
-    "query_knowledge_base",
-    "notify_progress",
-    "research_scratchpad",
-    "report_findings",
-    # Structured data source tools
-    "search_sec_edgar",
-    "fetch_sec_filing",
-    "search_osha",
-    "search_enr",
-    "search_wiki_solar",
-    "search_spw",
-]
 
 # Planning phase: KB + quick web/structured search + notify, no scratchpad or broad search
 PLANNING_TOOLS = [
@@ -96,6 +80,9 @@ async def run_research(
 ) -> tuple[AgentResult, list[dict], int]:
     """Run EPC research for a single project.
 
+    Delegates to the v2 gap-driven research loop. See research_loop.py
+    for the loop implementation.
+
     Args:
         project: Project dict from DB.
         knowledge_context: Optional KB briefing to include in the prompt.
@@ -105,238 +92,11 @@ async def run_research(
     Returns:
         (result, agent_log, total_tokens)
     """
-    from .db import get_anthropic_client
-
-    client = get_anthropic_client(api_key)
-
-    session_id = f"research-{project.get('id', 'unknown')}-{uuid4().hex[:8]}"
-    user_msg = build_user_message(project, knowledge_context)
-    user_msg += f"\n- **Session ID:** {session_id}"
-    if approved_plan:
-        user_msg += f"\n\n## Approved Research Plan\n{approved_plan}\n\nExecute this plan now."
-    messages = [{"role": "user", "content": user_msg}]
-    agent_log: list[dict] = []
-    total_tokens = 0
-
-    tools = get_tools(RESEARCH_TOOLS)
-    # Cache system + last tool for prompt caching (~90% input token savings)
-    cached_tools = [*tools[:-1], {**tools[-1], "cache_control": {"type": "ephemeral"}}]
-
-    # Track parsed tool results for health checking
-    recent_tool_outputs: list[dict] = []
-    # Effective iteration counter — notify_progress-only turns don't count
-    effective_iteration = 0
-
-    for iteration in range(MAX_ITERATIONS):
-        # Completeness checkpoint (Harvey AI pattern): at iterations 6, 12, 18
-        # evaluate what the agent has done and inject guidance into the last
-        # tool result.  Gentle → Firm → Mandatory escalation.
-        if effective_iteration in CHECKPOINTS and len(messages) > 1:
-            check = evaluate_completeness(effective_iteration, agent_log, recent_tool_outputs)
-            agent_log.append({"completeness_check": check})
-            logger.info(
-                "Completeness check at effective iteration %d (raw %d): %s (%s)",
-                effective_iteration,
-                iteration,
-                check["recommendation"],
-                check["level"],
-            )
-            if check["message"]:
-                # Inject into last tool_result message (append-only — preserves KV cache)
-                last_msg = messages[-1]
-                if isinstance(last_msg.get("content"), list) and last_msg["content"]:
-                    last_msg["content"][-1]["content"] += check["message"]
-
-        # Hard stop: at iteration 22+, strip all tools except report_findings
-        # to force the agent to conclude. The mandatory checkpoint at 18 is a
-        # text nudge the agent can ignore; this is structural — it literally
-        # cannot call anything else.
-        if effective_iteration >= HARD_STOP_ITERATION:
-            active_tools = [t for t in cached_tools if t["name"] == "report_findings"]
-            hard_stop_msg = (
-                "\n\nSYSTEM: You have exhausted your research budget. "
-                "The ONLY tool available to you now is report_findings. "
-                "Call it immediately with your best assessment."
-            )
-            # Inject into the last tool result
-            if len(messages) > 1:
-                last_msg = messages[-1]
-                if isinstance(last_msg.get("content"), list) and last_msg["content"]:
-                    last_msg["content"][-1]["content"] += hard_stop_msg
-        else:
-            active_tools = cached_tools
-
-        try:
-            response = await _call_api(
-                client,
-                model=MODEL,
-                max_tokens=4096,
-                system=[
-                    {
-                        "type": "text",
-                        "text": RESEARCH_SYSTEM_PROMPT,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
-                tools=active_tools,
-                messages=messages,
-            )
-        except anthropic.AuthenticationError as exc:
-            return (
-                AgentResult(
-                    reasoning="Authentication failed.",
-                    error=ResearchError(
-                        category="api_key_missing",
-                        message="Anthropic API key is invalid or missing.",
-                        detail=str(exc),
-                    ),
-                ),
-                agent_log,
-                total_tokens,
-            )
-        except anthropic.RateLimitError as exc:
-            logger.warning("Rate limit exceeded after 3 retries: %s", exc)
-            return (
-                AgentResult(
-                    reasoning="Anthropic API rate limit exceeded after retries.",
-                    error=ResearchError(
-                        category="anthropic_error",
-                        message="Rate limit exceeded after 3 retries.",
-                        detail=str(exc),
-                    ),
-                ),
-                agent_log,
-                total_tokens,
-            )
-        except anthropic.APIError as exc:
-            return (
-                AgentResult(
-                    reasoning=f"Anthropic API error: {exc}",
-                    error=ResearchError(
-                        category="anthropic_error",
-                        message=f"Anthropic API error: {type(exc).__name__}",
-                        detail=str(exc),
-                    ),
-                ),
-                agent_log,
-                total_tokens,
-            )
-
-        total_tokens += response.usage.input_tokens + response.usage.output_tokens
-        agent_log.append(
-            {
-                "iteration": iteration,
-                "stop_reason": response.stop_reason,
-                "input_tokens": response.usage.input_tokens,
-                "output_tokens": response.usage.output_tokens,
-            }
-        )
-
-        # 3d: Model stopped without tool use — end_turn without report_findings
-        if response.stop_reason == "end_turn":
-            text = ""
-            for block in response.content:
-                if block.type == "text":
-                    text += block.text
-            return (
-                AgentResult(
-                    reasoning=text or "Agent stopped without reporting findings.",
-                    error=ResearchError(
-                        category="no_report",
-                        message="Agent ended without calling report_findings.",
-                    ),
-                ),
-                agent_log,
-                total_tokens,
-            )
-
-        # Process tool use blocks
-        tool_results = []
-        report_result: AgentResult | None = None
-
-        for block in response.content:
-            if block.type != "tool_use":
-                continue
-
-            agent_log.append({"tool": block.name, "input": block.input})
-
-            if block.name == "report_findings":
-                # Parse structured findings into AgentResult
-                report_result = parse_report_findings(block.input)
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": "Findings recorded. Thank you.",
-                    }
-                )
-            else:
-                # Dispatch to shared tool handler
-                try:
-                    result = await execute_tool(block.name, block.input)
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": block.id,
-                            "content": json.dumps(result),
-                        }
-                    )
-                    recent_tool_outputs.append(result)
-                except Exception as e:
-                    error_result = {"error": str(e)}
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": block.id,
-                            "content": json.dumps(error_result),
-                            "is_error": True,
-                        }
-                    )
-                    recent_tool_outputs.append(error_result)
-
-        # If report_findings was called, we're done
-        if report_result is not None:
-            return report_result, agent_log, total_tokens
-
-        # Count this turn toward the effective budget only if the agent did
-        # real work (search, fetch, KB query, etc.). Turns that only call
-        # notify_progress or research_scratchpad are "status-only" and don't
-        # count — they waste the iteration budget otherwise.
-        tool_names_this_turn = {
-            block.name for block in response.content if block.type == "tool_use"
-        }
-        substantive_tools = tool_names_this_turn - {"notify_progress", "research_scratchpad"}
-        if substantive_tools:
-            effective_iteration += 1
-
-        # 3b: Check for consecutive tool errors — if 3+, tell agent to wrap up
-        healthy, health_msg = check_tool_health(recent_tool_outputs)
-        all_failing = not healthy
-        if all_failing and tool_results:
-            # Append bail-out instruction to last real tool result
-            tool_results[-1]["content"] += (
-                f"\n\nSYSTEM WARNING: {health_msg}. Tools are failing repeatedly. "
-                "Please call report_findings now with confidence 'unknown' "
-                "and document what went wrong in reasoning."
-            )
-
-        # Feed tool results back and continue
-        messages.append({"role": "assistant", "content": response.content})
-        messages.append({"role": "user", "content": tool_results})
-
-        # Context compaction is handled by the AgentRuntime in src/agents/research.py.
-
-    # 3c: Max iterations reached
-    return (
-        AgentResult(
-            reasoning="Research timed out after maximum iterations.",
-            error=ResearchError(
-                category="max_iterations",
-                message="Research timed out after maximum iterations without completing.",
-            ),
-        ),
-        agent_log,
-        total_tokens,
+    return await run_research_loop(
+        project=project,
+        knowledge_context=knowledge_context,
+        approved_plan=approved_plan,
+        api_key=api_key,
     )
 
 

--- a/agent/src/research_loop.py
+++ b/agent/src/research_loop.py
@@ -259,6 +259,20 @@ async def _run_search_round(
                 round_tokens,
                 failed_count,
             )
+        except anthropic.RateLimitError as exc:
+            logger.warning("Rate limit exceeded after retries: %s", exc)
+            return (
+                AgentResult(
+                    reasoning="Anthropic API rate limit exceeded after retries.",
+                    error=ResearchError(
+                        category="anthropic_error",
+                        message="Rate limit exceeded after retries.",
+                        detail=str(exc),
+                    ),
+                ),
+                round_tokens,
+                failed_count,
+            )
         except anthropic.APIError as exc:
             return (
                 AgentResult(

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -20,7 +20,7 @@ from tests.conftest import (
 
 
 class TestReportFindings:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_single_turn_report(self, MockClient, mock_exec_tool, sample_project):
         """Agent calls report_findings on the first tool_use turn."""
@@ -66,7 +66,7 @@ class TestReportFindings:
         assert result.reasoning == "Two sources confirm."
         assert tokens == 300
 
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_report_with_null_epc(self, MockClient, mock_exec_tool, sample_project):
         """Agent reports unknown with null epc_contractor."""
@@ -103,7 +103,7 @@ class TestReportFindings:
 
 
 class TestMultiTurn:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_search_then_report(self, MockClient, mock_exec_tool, sample_project):
         """Agent does a web_search, then calls report_findings."""
@@ -165,57 +165,44 @@ class TestMultiTurn:
 
 
 # ---------------------------------------------------------------------------
-# End turn (model finishes without report_findings)
+# Max depth / budget exhaustion
 # ---------------------------------------------------------------------------
 
 
-class TestEndTurn:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+class TestMaxDepth:
+    """V2 loop exhausts its depth budget and returns a structured error.
+
+    Replaces the v1 TestEndTurn / TestMaxIterations tests — v2 treats end_turn
+    as round-ending (reflection decides next step) rather than extracting text.
+    """
+
+    @patch("src.research_loop.MAX_DEPTH", 2)
+    @patch("src.research_loop.analyze_and_plan", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
-    async def test_end_turn_extracts_text(self, MockClient, mock_exec_tool, sample_project):
-        text_block = make_text_block("I could not determine the EPC.")
-        resp = make_claude_response(
-            stop_reason="end_turn",
-            content=[text_block],
-            input_tokens=100,
-            output_tokens=40,
-        )
-
-        mock_client = MagicMock()
-        mock_client.messages = MagicMock()
-        mock_client.messages.create = AsyncMock(return_value=resp)
-        MockClient.return_value = mock_client
-
-        result, log, tokens = await run_research(sample_project)
-
-        assert result.reasoning == "I could not determine the EPC."
-        assert result.epc_contractor is None
-        assert tokens == 140
-
-
-# ---------------------------------------------------------------------------
-# Max iterations
-# ---------------------------------------------------------------------------
-
-
-class TestMaxIterations:
-    @patch("src.research.MAX_ITERATIONS", 2)
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
-    @patch("src.research.anthropic.AsyncAnthropic")
-    async def test_max_iterations_returns_fallback(
-        self, MockClient, mock_exec_tool, sample_project
+    async def test_max_depth_returns_error(
+        self, MockClient, mock_exec_tool, mock_reflect, sample_project
     ):
-        """If agent hits max iterations without report_findings, return fallback."""
+        """If agent never calls report_findings and reflection keeps saying continue,
+        loop exhausts MAX_DEPTH and returns max_iterations error."""
+        from src.models import ReflectionResult
+
         search_block = make_tool_use_block(
             name="web_search",
             block_id="ws-loop",
-            input_data={"query": "search forever"},
+            input_data={"query": "never ending search"},
         )
         resp = make_claude_response(
             stop_reason="tool_use",
             content=[search_block],
         )
         mock_exec_tool.return_value = {"results": []}
+        mock_reflect.return_value = ReflectionResult(
+            summary="Still searching",
+            gaps=["Need more info"],
+            should_continue=True,
+            next_search_topic="another query",
+        )
 
         mock_client = MagicMock()
         mock_client.messages = MagicMock()
@@ -224,10 +211,9 @@ class TestMaxIterations:
 
         result, log, tokens = await run_research(sample_project)
 
-        assert "timed out" in result.reasoning.lower()
         assert result.error is not None
         assert result.error.category == "max_iterations"
-        assert mock_client.messages.create.call_count == 2
+        assert "budget" in result.reasoning.lower() or "iteration" in result.reasoning.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -236,7 +222,7 @@ class TestMaxIterations:
 
 
 class TestSearchErrors:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_search_error_feeds_back_error(self, MockClient, mock_exec_tool, sample_project):
         """Tool exception → error tool_result fed back, loop continues."""
@@ -285,7 +271,7 @@ class TestSearchErrors:
 
 
 class TestTokenCounting:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_tokens_accumulated_across_turns(
         self, MockClient, mock_exec_tool, sample_project
@@ -331,7 +317,7 @@ class TestTokenCounting:
 
 
 class TestTenacityRetry:
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_rate_limit_retries_then_succeeds(
         self, MockClient, mock_exec_tool, sample_project
@@ -374,7 +360,7 @@ class TestTenacityRetry:
         assert result.epc_contractor == "Blattner"
         assert mock_client.messages.create.call_count == 2
 
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_auth_error_fails_immediately(self, MockClient, mock_exec_tool, sample_project):
         """AuthenticationError -> immediate failure, no retries."""
@@ -399,7 +385,7 @@ class TestTenacityRetry:
         assert result.error.category == "api_key_missing"
         assert mock_client.messages.create.call_count == 1
 
-    @patch("src.research.execute_tool", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
     @patch("src.research.anthropic.AsyncAnthropic")
     async def test_three_rate_limits_returns_error(
         self, MockClient, mock_exec_tool, sample_project

--- a/agent/tests/test_e2e_v2.py
+++ b/agent/tests/test_e2e_v2.py
@@ -1,0 +1,130 @@
+"""End-to-end smoke test for the wired v2 research pipeline.
+
+Verifies the full path: run_research() → run_research_loop() → reflection →
+evidence → report_findings → AgentResult with upgraded confidence.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.conftest import make_claude_response, make_tool_use_block
+
+from src.models import AgentResult, ReflectionResult
+from src.research import run_research
+
+
+def _sample_project():
+    return {
+        "id": "e2e-v2-1",
+        "project_name": "Desert Sun Solar",
+        "queue_id": "Q-E2E-V2-1",
+        "developer": "AES Corporation",
+        "mw_capacity": 300,
+        "state": "CA",
+        "iso_region": "CAISO",
+    }
+
+
+class TestE2EV2:
+    @patch("src.research_loop.analyze_and_plan", new_callable=AsyncMock)
+    @patch("src.research_loop.execute_tool", new_callable=AsyncMock)
+    @patch("src.research.anthropic.AsyncAnthropic")
+    async def test_full_v2_pipeline_finds_epc(
+        self, MockClient, mock_exec_tool, mock_reflect, _sample_project=_sample_project
+    ):
+        """Full flow: search → reflect → verify → report through run_research()."""
+        project = _sample_project()
+
+        # Round 1: agent searches
+        round1_search = make_claude_response(
+            stop_reason="tool_use",
+            content=[make_tool_use_block(
+                name="web_search",
+                input_data={"query": "AES Desert Sun Solar EPC contractor"},
+                block_id="t1",
+            )],
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        # Round 1 continues: agent ends turn after getting search results
+        round1_end = make_claude_response(
+            stop_reason="end_turn",
+            content=[],
+            input_tokens=150,
+            output_tokens=40,
+        )
+
+        # After reflection says stop, forced report round
+        round_report = make_claude_response(
+            stop_reason="tool_use",
+            content=[make_tool_use_block(
+                name="report_findings",
+                block_id="t3",
+                input_data={
+                    "epc_contractor": "Mortenson",
+                    "confidence": "likely",
+                    "sources": [{
+                        "channel": "press_release",
+                        "excerpt": "Mortenson selected as EPC for 300MW Desert Sun",
+                        "url": "https://example.com/pr",
+                        "reliability": "high",
+                        "source_method": "tavily_search",
+                        "date": "2025-06-01",
+                    }],
+                    "reasoning": {
+                        "summary": "Mortenson identified as EPC from press release [1]",
+                        "supporting_evidence": ["Press release names Mortenson"],
+                        "gaps": [],
+                    },
+                    "searches_performed": ["AES Desert Sun Solar EPC contractor"],
+                    "negative_evidence": [],
+                },
+            )],
+            input_tokens=300,
+            output_tokens=150,
+        )
+
+        responses = [round1_search, round1_end, round_report]
+        call_idx = 0
+
+        async def side_effect(**kwargs):
+            nonlocal call_idx
+            resp = responses[min(call_idx, len(responses) - 1)]
+            call_idx += 1
+            return resp
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=side_effect)
+        MockClient.return_value = mock_client
+
+        # Reflection after round 1: says stop (sufficient evidence)
+        mock_reflect.return_value = ReflectionResult(
+            summary="Mortenson confirmed from press release",
+            gaps=[],
+            should_continue=False,
+        )
+
+        # Tool execution returns realistic search results
+        mock_exec_tool.return_value = {
+            "results": [{
+                "title": "Mortenson EPC Award",
+                "url": "https://example.com/pr",
+                "content": "Mortenson selected as EPC for AES's 300MW Desert Sun Solar project in California",
+                "score": 0.95,
+            }],
+        }
+
+        result, log, tokens = await run_research(
+            project=project,
+            knowledge_context="No prior research on this project.",
+        )
+
+        assert isinstance(result, AgentResult)
+        assert result.epc_contractor == "Mortenson"
+        assert result.confidence == "likely"
+        assert tokens > 0
+        # Verify reflection was called
+        assert mock_reflect.call_count >= 1
+        # Verify evidence was extracted (tool was called at least once)
+        assert mock_exec_tool.call_count >= 1


### PR DESCRIPTION
## Summary
- **The swap**: `run_research()` now delegates to `run_research_loop()` instead of running an inline v1 loop. ~250 lines of v1 iteration/checkpoint/hard-stop logic deleted.
- `run_research_plan()` is **untouched** — it has its own prompt and tools, unaffected.
- `RESEARCH_SYSTEM_PROMPT` updated to match v2's `[Research guidance: ...]` injection pattern.
- Added explicit `RateLimitError` handler in `research_loop.py` for cleaner error messages.
- Test infrastructure: migrated `test_agent.py` patches from `src.research.*` to `src.research_loop.*`. Replaced v1-specific tests (`TestEndTurn`, `TestMaxIterations`) with a single `TestMaxDepth` for v2 budget semantics. Added `test_e2e_v2.py` smoke test.

## Context
PR 5 in the research v2 stack. **This is the only PR in the stack that changes production behavior.** Depends on PR #21 (the dead-code loop).

After this merges, every research call in production routes through the gap-driven v2 pipeline: search → reflect → gap injection → search → report.

## Review focus areas
1. Does `run_research()` still satisfy the contract expected by `batch.py:66` and `main.py:171`? (Same signature, same 3-tuple return, same `AgentResult` shape.)
2. Does the updated `RESEARCH_SYSTEM_PROMPT` work for the AgentRuntime-based research path in `agents/research.py`? (That path imports the same prompt but doesn't inject guidance messages — prompt should still work, just without the between-round guidance.)
3. Test migration correctness: `test_agent.py` patches now point at `src.research_loop.execute_tool`. Spot-check one test to confirm the mock actually fires.
4. `TestMaxDepth` replaces two v1 tests. Is it covering equivalent behavior in v2 terms?

## What was deleted
- `MAX_ITERATIONS`, `HARD_STOP_ITERATION`, checkpoint injection logic (replaced by v2's time budget + reflection-based stopping)
- `completeness.py` import (no longer referenced — completeness module itself is untouched in case we want it back)
- v1 inline while-loop body (now lives in `research_loop._run_search_round`)
- `test_agent.py::TestEndTurn::test_end_turn_extracts_text` (v1 returned end_turn text as `reasoning`; v2 lets reflection decide next step)
- `test_agent.py::TestMaxIterations::test_max_iterations_returns_fallback` (replaced by `TestMaxDepth`)

## Test plan
- [x] Full suite: 678 passed, 0 regressions
- [x] E2E smoke test (`test_e2e_v2.py`) covers the full wired path
- [x] All 18 tests in `test_agent.py` + `test_request_guidance.py` pass
- [ ] Manual smoke test: run `POST /api/discover` against a real project with Anthropic key — verify findings come back
- [ ] Manual batch smoke test: run `POST /api/discover/batch` with 2-3 projects — verify concurrent execution still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)