### PR TITLE
fix(agent): restore contact persistence + cross-turn tool memory

### DIFF
--- a/agent/src/db.py
+++ b/agent/src/db.py
@@ -428,7 +428,9 @@ def store_contacts(entity_id: str, contacts: list[dict]) -> list[dict]:
         }
         try:
             resp = (
-                client.table("contacts").upsert(data, on_conflict="entity_id,full_name").execute()
+                client.table("contacts")
+                .upsert(data, on_conflict="entity_id,full_name_lower")
+                .execute()
             )
             if resp.data:
                 stored.append(resp.data[0])

--- a/agent/src/main.py
+++ b/agent/src/main.py
@@ -53,6 +53,7 @@ from .models import (
     HubSpotPushRequest,
     NegativeEvidence,
     ReviewRequest,
+    build_anthropic_messages,
 )
 from .research import run_research, run_research_plan
 from .sse import StreamWriter
@@ -984,9 +985,10 @@ async def chat(req: ChatRequest, request: Request, _user_id: str = Depends(requi
             conversation_id, "user", last.get_text(), parts=persist_parts, user_id=_user_id
         )
 
-    # Build message history for the agent (Anthropic API needs role + content)
-    # Use get_content_blocks() to pass file attachments as native Claude content blocks
-    messages = [{"role": m.role, "content": m.get_content_blocks()} for m in req.messages]
+    # Build message history for the agent — reconstructs Anthropic
+    # tool_use / tool_result pairing from AI SDK tool-invocation parts so
+    # Claude retains memory of prior tool calls across turns.
+    messages = build_anthropic_messages(req.messages)
 
     # Create job and spawn background task
     job_id = str(uuid.uuid4())

--- a/agent/src/models.py
+++ b/agent/src/models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import json
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -106,12 +107,21 @@ class AgentResult(BaseModel):
 
 
 class ChatMessagePart(BaseModel):
-    type: str  # "text", "file"
+    type: str  # "text" | "file" | "tool-invocation"
     text: str | None = None
     # File attachment fields (type="file") — AI SDK FileUIPart format
     mediaType: str | None = None  # MIME type: "application/pdf", "image/png", etc.
     filename: str | None = None
     url: str | None = None  # data URL: "data:<mediaType>;base64,<data>"
+    # Tool-invocation fields (type="tool-invocation") — AI SDK useChat format.
+    # Present on past assistant messages shipped back by the frontend so the
+    # server can rehydrate Anthropic tool_use + tool_result blocks and Claude
+    # retains memory of prior tool calls across turns.
+    toolCallId: str | None = None
+    toolName: str | None = None
+    input: dict | None = None
+    output: Any | None = None
+    state: str | None = None  # "result" | "partial-call"
 
 
 # Supported file types and their Claude API content block mappings
@@ -214,6 +224,94 @@ def _extract_base64(data_url: str) -> str | None:
         return parts[1] if len(parts) == 2 else None
     # Already raw base64
     return data_url
+
+
+def build_anthropic_messages(messages: list[ChatMessage]) -> list[dict]:
+    """Convert AI SDK chat history to Anthropic API messages.
+
+    Each assistant ``tool-invocation`` part is split into paired ``tool_use``
+    blocks (on the assistant message) and ``tool_result`` blocks (prepended
+    to the next user message). Without this pairing, Claude loses memory of
+    prior tool calls across turns because the AI SDK ships tool metadata as
+    a part type the legacy parser dropped silently. See
+    ``docs/superpowers/specs/2026-04-06-agent-memory-persistence-issues.md``
+    for the original incident report.
+
+    Partial tool-invocations (``output is None``) are dropped entirely —
+    emitting a ``tool_use`` without a matching ``tool_result`` violates the
+    Anthropic API contract.
+    """
+    out: list[dict] = []
+    pending_tool_results: list[dict] = []
+
+    def _flush_pending_as_user() -> None:
+        nonlocal pending_tool_results
+        if pending_tool_results:
+            out.append({"role": "user", "content": pending_tool_results})
+            pending_tool_results = []
+
+    for msg in messages:
+        if msg.role == "assistant":
+            # Flush orphaned tool_results before starting a new assistant turn
+            # (defensive — normal chat flow never produces back-to-back
+            # assistant messages).
+            _flush_pending_as_user()
+
+            assistant_blocks: list[dict] = []
+            for p in msg.parts or []:
+                if p.type == "text" and p.text:
+                    assistant_blocks.append({"type": "text", "text": p.text})
+                elif p.type == "tool-invocation" and p.toolCallId and p.output is not None:
+                    assistant_blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": p.toolCallId,
+                            "name": p.toolName or "",
+                            "input": p.input if isinstance(p.input, dict) else {},
+                        }
+                    )
+                    content = (
+                        p.output if isinstance(p.output, str) else json.dumps(p.output, default=str)
+                    )
+                    pending_tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": p.toolCallId,
+                            "content": content,
+                        }
+                    )
+                # Partial tool-invocations are intentionally dropped.
+
+            # Legacy fallback: messages saved before parts existed used .content
+            if not assistant_blocks and msg.content:
+                assistant_blocks.append({"type": "text", "text": msg.content})
+
+            if assistant_blocks:
+                out.append({"role": "assistant", "content": assistant_blocks})
+            continue
+
+        # User message
+        user_blocks = msg.get_content_blocks()
+        if isinstance(user_blocks, str):
+            user_content: list[dict] = (
+                [{"type": "text", "text": user_blocks}] if user_blocks else []
+            )
+        else:
+            user_content = list(user_blocks)
+
+        if pending_tool_results:
+            user_content = pending_tool_results + user_content
+            pending_tool_results = []
+
+        if user_content:
+            out.append({"role": msg.role, "content": user_content})
+
+    # Edge case: history ends on an assistant with pending tool_results
+    # (shouldn't happen in normal chat flow — a new turn is only triggered
+    # by a user message). Emit them as a trailing synthetic user message to
+    # stay API-valid.
+    _flush_pending_as_user()
+    return out
 
 
 class ChatRequest(BaseModel):

--- a/agent/src/tools/save_contact.py
+++ b/agent/src/tools/save_contact.py
@@ -1,7 +1,8 @@
 """Save a discovered contact to the database.
 
-Upserts into the `contacts` table (dedup on entity_id + lower(full_name))
-and optionally links the contact to a project via `project_contacts`.
+Upserts into the `contacts` table (dedup on entity_id + full_name_lower, a
+stored generated column = lower(full_name)) and optionally links the contact
+to a project via `project_contacts`.
 """
 
 from __future__ import annotations
@@ -131,7 +132,7 @@ async def execute(tool_input: dict) -> dict:
     try:
         resp = (
             client.table("contacts")
-            .upsert(contact_data, on_conflict="entity_id,lower(full_name)")
+            .upsert(contact_data, on_conflict="entity_id,full_name_lower")
             .execute()
         )
         contact_row = resp.data[0] if resp.data else {}

--- a/agent/tests/test_models.py
+++ b/agent/tests/test_models.py
@@ -8,9 +8,12 @@ from pydantic import ValidationError
 from src.models import (
     AgentResult,
     BatchDiscoverRequest,
+    ChatMessage,
+    ChatMessagePart,
     DiscoverRequest,
     EpcSource,
     ReviewRequest,
+    build_anthropic_messages,
 )
 
 # -- DiscoverRequest ----------------------------------------------------------
@@ -130,3 +133,284 @@ class TestAgentResult:
         dumped = r.sources[0].model_dump()
         assert dumped["channel"] == "permit_filing"
         assert dumped["reliability"] == "medium"
+
+
+# -- build_anthropic_messages ------------------------------------------------
+#
+# Regression guard for the turn-to-turn memory bug documented in
+# docs/superpowers/specs/2026-04-06-agent-memory-persistence-issues.md.
+# Without proper tool_use/tool_result pairing, Claude forgets tool calls
+# across chat turns and re-runs searches from scratch.
+
+
+def _user(text: str) -> ChatMessage:
+    return ChatMessage(
+        role="user",
+        parts=[ChatMessagePart(type="text", text=text)],
+    )
+
+
+def _assistant_text(text: str) -> ChatMessage:
+    return ChatMessage(
+        role="assistant",
+        parts=[ChatMessagePart(type="text", text=text)],
+    )
+
+
+class TestBuildAnthropicMessages:
+    def test_plain_text_roundtrip(self):
+        """User → assistant text → user: no tools, pure text."""
+        msgs = [
+            _user("hi"),
+            _assistant_text("hello"),
+            _user("what's up"),
+        ]
+        out = build_anthropic_messages(msgs)
+
+        assert len(out) == 3
+        assert out[0] == {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+        assert out[1] == {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+        }
+        assert out[2] == {
+            "role": "user",
+            "content": [{"type": "text", "text": "what's up"}],
+        }
+
+    def test_single_tool_invocation_pairs_tool_use_and_tool_result(self):
+        """Assistant with one tool-invocation splits into tool_use + next-user tool_result."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(type="text", text="Looking it up."),
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_01",
+                    toolName="search_projects",
+                    input={"state": "TX"},
+                    output={"count": 3},
+                    state="result",
+                ),
+            ],
+        )
+        msgs = [_user("find projects"), assistant, _user("thanks")]
+
+        out = build_anthropic_messages(msgs)
+
+        # user → assistant (text + tool_use) → user (tool_result + new text)
+        assert len(out) == 3
+
+        assert out[1] == {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Looking it up."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01",
+                    "name": "search_projects",
+                    "input": {"state": "TX"},
+                },
+            ],
+        }
+
+        # tool_result is prepended to the next user message
+        assert out[2]["role"] == "user"
+        assert out[2]["content"][0] == {
+            "type": "tool_result",
+            "tool_use_id": "toolu_01",
+            "content": '{"count": 3}',
+        }
+        assert out[2]["content"][1] == {"type": "text", "text": "thanks"}
+
+    def test_multiple_tool_invocations_in_one_turn(self):
+        """All tool_use blocks emitted in order; all tool_results prepended to next user."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_A",
+                    toolName="search_exa_people",
+                    input={"query": "Rosendin EPC"},
+                    output="exa result text",
+                    state="result",
+                ),
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_B",
+                    toolName="search_linkedin",
+                    input={"company": "Rosendin"},
+                    output={"results": []},
+                    state="result",
+                ),
+                ChatMessagePart(type="text", text="Here are the candidates."),
+            ],
+        )
+        msgs = [_user("find contacts"), assistant, _user("now enrich them")]
+
+        out = build_anthropic_messages(msgs)
+
+        # Assistant carries tool_use A + tool_use B + trailing text, in order
+        assistant_content = out[1]["content"]
+        assert [b["type"] for b in assistant_content] == ["tool_use", "tool_use", "text"]
+        assert assistant_content[0]["id"] == "toolu_A"
+        assert assistant_content[1]["id"] == "toolu_B"
+
+        # Next user message starts with both tool_results in order, then the new text
+        next_user = out[2]["content"]
+        assert next_user[0] == {
+            "type": "tool_result",
+            "tool_use_id": "toolu_A",
+            "content": "exa result text",
+        }
+        assert next_user[1] == {
+            "type": "tool_result",
+            "tool_use_id": "toolu_B",
+            "content": '{"results": []}',
+        }
+        assert next_user[2] == {"type": "text", "text": "now enrich them"}
+
+    def test_partial_tool_invocation_is_dropped(self):
+        """state=partial-call with no output: omit entirely (no orphan tool_use)."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(type="text", text="Searching…"),
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_partial",
+                    toolName="search_projects",
+                    input={"state": "TX"},
+                    output=None,
+                    state="partial-call",
+                ),
+            ],
+        )
+        msgs = [_user("q"), assistant, _user("follow up")]
+
+        out = build_anthropic_messages(msgs)
+
+        # Assistant has only the text block, no tool_use
+        assert out[1]["content"] == [{"type": "text", "text": "Searching…"}]
+        # Next user message has no tool_result, just the new text
+        assert out[2] == {
+            "role": "user",
+            "content": [{"type": "text", "text": "follow up"}],
+        }
+
+    def test_dict_output_is_json_stringified(self):
+        """tool_result.content must be a string — dict outputs get json.dumps'd."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_x",
+                    toolName="find_contacts",
+                    input={},
+                    output={"contacts": [{"name": "Duncan Frederick"}]},
+                    state="result",
+                ),
+            ],
+        )
+        msgs = [_user("q"), assistant, _user("next")]
+
+        out = build_anthropic_messages(msgs)
+
+        tr = out[2]["content"][0]
+        assert tr["type"] == "tool_result"
+        assert isinstance(tr["content"], str)
+        assert "Duncan Frederick" in tr["content"]
+
+    def test_string_output_passes_through_unmodified(self):
+        """Tool outputs that are already strings must not be double-encoded."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_s",
+                    toolName="think",
+                    input={"thought": "…"},
+                    output="plain string output",
+                    state="result",
+                ),
+            ],
+        )
+        msgs = [_user("q"), assistant, _user("next")]
+
+        out = build_anthropic_messages(msgs)
+
+        assert out[2]["content"][0]["content"] == "plain string output"
+
+    def test_trailing_assistant_emits_synthetic_user_tool_results(self):
+        """History ending on an assistant with tool-invocations must still be API-valid."""
+        assistant = ChatMessage(
+            role="assistant",
+            parts=[
+                ChatMessagePart(
+                    type="tool-invocation",
+                    toolCallId="toolu_last",
+                    toolName="search_projects",
+                    input={},
+                    output={"ok": True},
+                    state="result",
+                ),
+            ],
+        )
+        msgs = [_user("q"), assistant]
+
+        out = build_anthropic_messages(msgs)
+
+        # user, assistant (tool_use), synthetic user (tool_result)
+        assert len(out) == 3
+        assert out[1]["role"] == "assistant"
+        assert out[1]["content"][0]["type"] == "tool_use"
+        assert out[2]["role"] == "user"
+        assert out[2]["content"][0]["type"] == "tool_result"
+        assert out[2]["content"][0]["tool_use_id"] == "toolu_last"
+
+    def test_legacy_content_only_assistant_message(self):
+        """Messages saved before parts existed use .content — must still be emitted as text."""
+        assistant = ChatMessage(role="assistant", content="pre-parts-era response")
+        msgs = [_user("q"), assistant, _user("next")]
+
+        out = build_anthropic_messages(msgs)
+
+        assert out[1] == {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "pre-parts-era response"}],
+        }
+
+    def test_user_file_part_preserved(self):
+        """User file parts still become image/document blocks.
+
+        Guards against regressing the existing ``get_content_blocks()`` path
+        while adding tool-invocation handling.
+        """
+        # 1x1 transparent PNG base64 (split to satisfy line-length lint)
+        png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+            "YAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        )
+        user_with_image = ChatMessage(
+            role="user",
+            parts=[
+                ChatMessagePart(type="text", text="what's in this?"),
+                ChatMessagePart(
+                    type="file",
+                    mediaType="image/png",
+                    filename="pixel.png",
+                    url=f"data:image/png;base64,{png_b64}",
+                ),
+            ],
+        )
+        msgs = [user_with_image]
+
+        out = build_anthropic_messages(msgs)
+
+        assert len(out) == 1
+        types = [b["type"] for b in out[0]["content"]]
+        assert "text" in types
+        assert "image" in types

--- a/agent/tests/test_save_contact.py
+++ b/agent/tests/test_save_contact.py
@@ -119,6 +119,29 @@ async def test_valid_input_upserts_contact():
 
 
 @pytest.mark.asyncio
+async def test_upsert_uses_generated_column_for_on_conflict():
+    """Regression guard for Supabase/PostgREST bug.
+
+    PostgREST cannot reference expression indexes (e.g. ``lower(full_name)``)
+    in its ``on_conflict`` query parameter — it tries to resolve ``lower`` as
+    a column name and Postgres errors with ``column "lower" does not exist``.
+    The fix (migration 030) adds a stored generated column
+    ``full_name_lower`` and indexes it directly. This test pins the
+    ``on_conflict`` string so we don't silently regress back to the
+    expression form.
+    """
+    from src.tools.save_contact import execute
+
+    client, contacts_tbl, _pc_tbl = _make_client()
+
+    with patch("src.tools.save_contact.get_client", return_value=client):
+        await execute(VALID_INPUT)
+
+    _args, kwargs = contacts_tbl.upsert.call_args
+    assert kwargs.get("on_conflict") == "entity_id,full_name_lower"
+
+
+@pytest.mark.asyncio
 async def test_optional_fields_included_in_upsert():
     from src.tools.save_contact import execute
 

--- a/supabase/migrations/030_contacts_full_name_lower.sql
+++ b/supabase/migrations/030_contacts_full_name_lower.sql
@@ -1,0 +1,28 @@
+-- Fix save_contact upsert: PostgREST cannot reference expression indexes in
+-- the `on_conflict` query parameter, so replace the expression-based unique
+-- index on (entity_id, lower(full_name)) with a stored generated column +
+-- a plain column-based unique index.
+--
+-- Backfill is automatic: GENERATED ALWAYS AS ... STORED populates existing
+-- rows at ADD COLUMN time. The replacement index preserves the same
+-- uniqueness semantics (case-insensitive dedup per entity), so no existing
+-- rows can newly collide.
+--
+-- Every statement is idempotent so this migration is safe to re-run after
+-- a partial application (e.g. if a prior run left the column in place but
+-- never got to CREATE INDEX).
+--
+-- Verify manually after running:
+--   SELECT column_name, is_generated, generation_expression
+--     FROM information_schema.columns
+--    WHERE table_name = 'contacts' AND column_name = 'full_name_lower';
+--   Expected: is_generated='ALWAYS', generation_expression='lower(full_name)'
+
+DROP INDEX IF EXISTS idx_contacts_entity_name;
+
+ALTER TABLE contacts
+  ADD COLUMN IF NOT EXISTS full_name_lower TEXT
+  GENERATED ALWAYS AS (lower(full_name)) STORED;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_entity_name_lower
+  ON contacts (entity_id, full_name_lower);


### PR DESCRIPTION
## Summary

Two related bugs that together broke the "find contacts → draft outreach → enrich" flow. Diagnosed via the systematic-debugging skill — see the full root-cause trace for Issue #2 in `docs/superpowers/specs/2026-04-06-agent-memory-persistence-issues.md`.

### Issue 1 — `save_contact` failing with "column 'lower' does not exist"
PostgREST cannot reference expression indexes in its `on_conflict` query parameter — when it sees `lower(full_name)` it tries to resolve `lower` as a column name. Every save_contact call was failing in production, which also blocked enrichment downstream since `enrich_contact_email` / `enrich_contact_phone` require the `contact_id` that `save_contact` returns.

Fix: replace the expression unique index with a stored generated column `full_name_lower` and a plain column-based unique index. Migration 030 is idempotent (uses `IF NOT EXISTS` / `IF EXISTS` on all statements) so a partial prior run can be safely re-applied.

### Issue 2 — agent forgot tool results between chat turns
`ChatMessagePart` only accepted `"text"` and `"file"` types. Pydantic silently dropped AI SDK `tool-invocation` parts shipped back by the frontend, so Claude saw only the text prose of past assistant messages — no `tool_use` / `tool_result` blocks. Agent re-ran searches from scratch on every follow-up.

Fix: extend `ChatMessagePart` with optional tool-invocation fields, add `build_anthropic_messages()` that walks the history and splits each assistant's tool-invocation parts into paired `tool_use` blocks (on the assistant message) and `tool_result` blocks (prepended to the next user message). Handles partial invocations, trailing-assistant edge case, and the legacy `.content` fallback.

## Commits
- `1d6a117` fix(contacts): replace expression-index on_conflict with generated column
- `6b62a1f` fix(chat): preserve tool-invocation parts across turns for memory retention

## Test plan
- [x] `pytest agent/tests/` → 717 passed, 1 skipped (includes 9 new tests for `build_anthropic_messages` + 1 regression guard for `on_conflict` string)
- [x] `ruff check` + `ruff format --check` clean
- [x] Apply migration 030 against Supabase (`supabase db push` or dashboard SQL editor), then verify:
  ```sql
  SELECT column_name, is_generated, generation_expression
    FROM information_schema.columns
   WHERE table_name = 'contacts' AND column_name = 'full_name_lower';
  ```
  Expect: `is_generated='ALWAYS'`, `generation_expression='lower(full_name)'`
- [ ] Deploy backend, then in chat:
  1. "Find contacts at Rosendin" → multiple contacts saved
  2. Follow-up: "draft outreach to Rick and Michael" → confirm agent references the existing contacts by name/LinkedIn URL without re-running `search_exa_people`
  3. Enrichment tools (`enrich_contact_email`) can now run with the returned contact_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now supports tool invocation and result sequencing so tool calls and their outputs appear correctly in conversation history.

* **Bug Fixes**
  * Contact deduplication now uses case-insensitive name matching to reduce duplicate entries.

* **Tests**
  * Added tests validating message transformation behavior, tool-call/result handling, and the contact upsert change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->