### PR TITLE
feat: add firecrawl_scrape tool for JS-rendered page fetching

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "tenacity>=8.2.0",
     "python-dotenv>=1.1.0",
     "pymupdf>=1.24.0",
+    "firecrawl-py>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/agent/src/tools/__init__.py
+++ b/agent/src/tools/__init__.py
@@ -32,6 +32,7 @@ from . import (
     fetch_page,
     fetch_sec_filing,
     find_contacts,
+    firecrawl_scrape,
     get_discoveries,
     lookup_hubspot_contacts,
     manage_todo,
@@ -78,6 +79,7 @@ _register(web_search)
 _register(brave_search)
 _register(export_csv)
 _register(fetch_page)
+_register(firecrawl_scrape)
 _register(fetch_sec_filing)
 _register(find_contacts)
 _register(push_to_hubspot)

--- a/agent/src/tools/firecrawl_scrape.py
+++ b/agent/src/tools/firecrawl_scrape.py
@@ -91,8 +91,9 @@ def _scrape_sync(url: str, api_key: str) -> dict:
     except Exception:  # noqa: BLE001
         logger.debug("firecrawl_scrape: could not read status_code from metadata")
 
+    _TRUNCATION_SUFFIX = "[... truncated]"
     if len(markdown) > _MAX_CHARS:
-        markdown = markdown[:_MAX_CHARS] + "[... truncated]"
+        markdown = markdown[: _MAX_CHARS - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
 
     return {
         "url": url,
@@ -123,7 +124,14 @@ async def execute(tool_input: dict) -> dict:
     if not api_key:
         return {"error": "FIRECRAWL_API_KEY not set. Firecrawl scraping is unavailable."}
 
-    result = await asyncio.to_thread(_scrape_sync, url, api_key)
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_scrape_sync, url, api_key),
+            timeout=_SCRAPE_TIMEOUT_MS / 1000.0,
+        )
+    except TimeoutError:
+        logger.warning("firecrawl_scrape wall-clock timeout for %s", url)
+        return {"error": f"Firecrawl scrape timed out after {_SCRAPE_TIMEOUT_MS // 1000}s."}
 
     if "error" not in result:
         _cache[url] = (time.monotonic(), result)

--- a/agent/src/tools/firecrawl_scrape.py
+++ b/agent/src/tools/firecrawl_scrape.py
@@ -1,0 +1,131 @@
+"""Firecrawl scrape tool — JS-rendered page fetching via Firecrawl API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from urllib.parse import urlparse
+
+import firecrawl
+
+logger = logging.getLogger(__name__)
+
+_MAX_CHARS = 20_000
+_MAX_URL_LENGTH = 2000
+_SCRAPE_TIMEOUT_MS = 30_000
+_CACHE_TTL = 900  # 15 minutes
+
+# In-memory cache: url -> (timestamp, result_dict)
+_cache: dict[str, tuple[float, dict]] = {}
+
+DEFINITION = {
+    "name": "firecrawl_scrape",
+    "description": (
+        "Fetch a web page and extract its content as clean markdown using "
+        "Firecrawl. Unlike fetch_page, this tool handles JavaScript-rendered "
+        "pages (React/Angular/Vue sites, EPC portfolio pages behind JS "
+        "frameworks, cookie consent walls). Use this when fetch_page returns "
+        "an error like 'Could not extract article text' or when you know the "
+        "target site requires JavaScript. Returns cleaned markdown truncated "
+        "to ~20,000 characters. Costs 1 Firecrawl credit per call — prefer "
+        "fetch_page for static HTML pages."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The full URL to fetch (must start with http:// or https://).",
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+
+def _validate_url(url: str) -> str | None:
+    """Return an error message string, or None if the URL is valid."""
+    if not url:
+        return "URL must not be empty."
+
+    if len(url) > _MAX_URL_LENGTH:
+        return f"URL exceeds maximum length of {_MAX_URL_LENGTH} characters."
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "URL could not be parsed."
+
+    if parsed.scheme not in ("http", "https"):
+        return f"URL scheme '{parsed.scheme}' is not allowed; must be http or https."
+
+    if parsed.username or parsed.password:
+        return "URL must not contain credentials (username or password)."
+
+    hostname = parsed.hostname or ""
+    if "." not in hostname:
+        return f"URL hostname '{hostname}' does not appear to be a valid domain (no dot found)."
+
+    return None
+
+
+def _scrape_sync(url: str, api_key: str) -> dict:
+    """Synchronous wrapper for the Firecrawl SDK. Returns a result dict or error dict."""
+    try:
+        timeout_seconds = _SCRAPE_TIMEOUT_MS / 1000.0
+        app = firecrawl.FirecrawlApp(api_key=api_key, timeout=timeout_seconds)
+        doc = app.scrape(url, formats=["markdown"], only_main_content=True)
+    except Exception as exc:
+        logger.warning("firecrawl_scrape SDK error for %s: %s", url, exc)
+        return {"error": str(exc)}
+
+    markdown = doc.markdown
+    if not markdown or not markdown.strip():
+        return {"error": f"Could not extract content from {url}: page returned empty markdown."}
+
+    status_code = None
+    try:
+        status_code = doc.metadata.status_code
+    except Exception:  # noqa: BLE001
+        logger.debug("firecrawl_scrape: could not read status_code from metadata")
+
+    if len(markdown) > _MAX_CHARS:
+        markdown = markdown[:_MAX_CHARS] + "[... truncated]"
+
+    return {
+        "url": url,
+        "text": markdown,
+        "length": len(markdown),
+        "source": "firecrawl",
+        "status_code": status_code,
+    }
+
+
+async def execute(tool_input: dict) -> dict:
+    """Fetch a JS-rendered page via Firecrawl, with in-memory caching."""
+    url = tool_input.get("url", "")
+
+    # Validate URL before checking API key so we fail fast on bad inputs
+    validation_error = _validate_url(url)
+    if validation_error:
+        return {"error": validation_error}
+
+    # Check cache
+    now = time.monotonic()
+    if url in _cache:
+        cached_at, cached_result = _cache[url]
+        if now - cached_at < _CACHE_TTL:
+            return {**cached_result, "cached": True}
+
+    api_key = os.environ.get("FIRECRAWL_API_KEY")
+    if not api_key:
+        return {"error": "FIRECRAWL_API_KEY not set. Firecrawl scraping is unavailable."}
+
+    result = await asyncio.to_thread(_scrape_sync, url, api_key)
+
+    if "error" not in result:
+        _cache[url] = (time.monotonic(), result)
+
+    return result

--- a/agent/tests/test_firecrawl_scrape.py
+++ b/agent/tests/test_firecrawl_scrape.py
@@ -136,7 +136,7 @@ class TestExecute:
 
         assert "error" not in result
         assert result["text"].endswith("[... truncated]")
-        assert len(result["text"]) <= _MAX_CHARS + len("[... truncated]") + 5
+        assert len(result["text"]) == _MAX_CHARS
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
@@ -185,6 +185,28 @@ class TestExecute:
         assert "error" in result
         msg = result["error"].lower()
         assert "empty" in msg or "extract" in msg
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_wall_clock_timeout_returns_error(self):
+        """When the threaded call exceeds the wall-clock timeout, return a timeout error."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        def hang_briefly(url, api_key):
+            import time
+
+            time.sleep(2)  # simulate a hung SDK call (short so test suite stays fast)
+
+        with (
+            patch("src.tools.firecrawl_scrape._scrape_sync", side_effect=hang_briefly),
+            patch("src.tools.firecrawl_scrape._SCRAPE_TIMEOUT_MS", 100),  # 0.1s timeout
+        ):
+            result = await execute({"url": "https://example.com/timeout"})
+
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})

--- a/agent/tests/test_firecrawl_scrape.py
+++ b/agent/tests/test_firecrawl_scrape.py
@@ -1,0 +1,272 @@
+"""Tests for firecrawl_scrape tool module."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.tools.firecrawl_scrape import _MAX_CHARS, _validate_url, execute
+
+# ---------------------------------------------------------------------------
+# TestValidateUrl
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrl:
+    def test_valid_https_url(self):
+        assert _validate_url("https://example.com/page") is None
+
+    def test_valid_http_url(self):
+        assert _validate_url("http://example.com/page") is None
+
+    def test_valid_url_with_path_and_query(self):
+        assert _validate_url("https://example.com/path?q=1&r=2") is None
+
+    def test_rejects_empty_string(self):
+        result = _validate_url("")
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_rejects_non_http_scheme_ftp(self):
+        result = _validate_url("ftp://example.com/file.txt")
+        assert result is not None
+
+    def test_rejects_non_http_scheme_file(self):
+        result = _validate_url("file:///etc/passwd")
+        assert result is not None
+
+    def test_rejects_url_with_credentials(self):
+        result = _validate_url("https://user:pass@example.com/page")
+        assert result is not None
+
+    def test_rejects_url_with_username_only(self):
+        result = _validate_url("https://user@example.com/page")
+        assert result is not None
+
+    def test_rejects_url_over_2000_chars(self):
+        long_url = "https://example.com/" + "a" * 2000
+        result = _validate_url(long_url)
+        assert result is not None
+
+    def test_accepts_url_at_exactly_2000_chars(self):
+        # Build URL that is exactly 2000 chars
+        base = "https://example.com/"
+        path = "a" * (2000 - len(base))
+        url = base + path
+        assert len(url) == 2000
+        assert _validate_url(url) is None
+
+    def test_rejects_url_without_dot_in_hostname(self):
+        result = _validate_url("http://localhost/page")
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# TestExecute
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_error(self):
+        """When FIRECRAWL_API_KEY is not set, return error with key name in message."""
+        env = {k: v for k, v in os.environ.items() if k != "FIRECRAWL_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            result = await execute({"url": "https://example.com"})
+
+        assert "error" in result
+        assert "FIRECRAWL_API_KEY" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_invalid_url_returns_error(self):
+        result = await execute({"url": "ftp://example.com/file"})
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_successful_scrape_returns_expected_fields(self):
+        """Successful scrape returns url, text, length, source, status_code."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = "# Hello World\n\nThis is content."
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            result = await execute({"url": "https://example.com"})
+
+        assert "error" not in result
+        assert result["url"] == "https://example.com"
+        assert result["text"] == "# Hello World\n\nThis is content."
+        assert result["length"] == len("# Hello World\n\nThis is content.")
+        assert result["source"] == "firecrawl"
+        assert result["status_code"] == 200
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_content_over_max_chars_is_truncated(self):
+        """Content exceeding _MAX_CHARS is truncated with '[... truncated]' suffix."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        long_content = "x" * (_MAX_CHARS + 5000)
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = long_content
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com/long"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            result = await execute({"url": "https://example.com/long"})
+
+        assert "error" not in result
+        assert result["text"].endswith("[... truncated]")
+        assert len(result["text"]) <= _MAX_CHARS + len("[... truncated]") + 5
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_empty_markdown_returns_error(self):
+        """When SDK returns empty/None markdown, return error with 'empty' or 'extract'."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = None
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com/empty"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            result = await execute({"url": "https://example.com/empty"})
+
+        assert "error" in result
+        msg = result["error"].lower()
+        assert "empty" in msg or "extract" in msg
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_empty_string_markdown_returns_error(self):
+        """When SDK returns empty string markdown, return error."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = "   "  # whitespace only
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com/ws"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            result = await execute({"url": "https://example.com/ws"})
+
+        assert "error" in result
+        msg = result["error"].lower()
+        assert "empty" in msg or "extract" in msg
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_sdk_exception_returns_error(self):
+        """When SDK raises, return error dict with exception message."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_app = MagicMock()
+        mock_app.scrape.side_effect = RuntimeError("connection refused")
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            result = await execute({"url": "https://example.com/fail"})
+
+        assert "error" in result
+        assert "connection refused" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TestCache
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_second_call_hits_cache(self):
+        """Second call for same URL hits cache; SDK called only once, result has cached=True."""
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = "# Cached Content"
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com/cached"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        url = "https://example.com/cached"
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            first = await execute({"url": url})
+            second = await execute({"url": url})
+
+        # SDK must have been called exactly once across both execute() calls
+        assert mock_app.scrape.call_count == 1
+        assert "error" not in first
+        assert second.get("cached") is True
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FIRECRAWL_API_KEY": "test-key"})
+    async def test_expired_cache_calls_sdk_again(self):
+        """When cached entry is past TTL, SDK is called again."""
+        import time
+
+        from src.tools import firecrawl_scrape
+
+        firecrawl_scrape._cache.clear()
+
+        mock_doc = MagicMock()
+        mock_doc.markdown = "# Fresh Content"
+        mock_doc.metadata = MagicMock()
+        mock_doc.metadata.status_code = 200
+        mock_doc.metadata.source_url = "https://example.com/ttl"
+
+        mock_app = MagicMock()
+        mock_app.scrape.return_value = mock_doc
+
+        url = "https://example.com/ttl"
+
+        with patch("src.tools.firecrawl_scrape.firecrawl.FirecrawlApp", return_value=mock_app):
+            await execute({"url": url})
+
+            # Manually expire the cache entry
+            old_time = time.monotonic() - firecrawl_scrape._CACHE_TTL - 1
+            firecrawl_scrape._cache[url] = (old_time, firecrawl_scrape._cache[url][1])
+
+            result = await execute({"url": url})
+
+        assert mock_app.scrape.call_count == 2
+        assert result.get("cached") is not True


### PR DESCRIPTION
## Summary
- Adds `firecrawl-py` dependency + `firecrawl_scrape` tool for fetching JavaScript-rendered web pages
- Mirrors Claude Code's `WebFetch` pattern: URL validation, 15-min in-memory cache, content truncation, structured errors
- Registers the tool in the existing registry — no existing behavior changes

## Why
`fetch_page` (trafilatura) fails on JS-heavy EPC portfolio pages — returns empty or stub content like "Enable JavaScript and cookies to continue." This PR adds Firecrawl as a standalone option so the agent can handle those pages.

Tested on rosendin.com/projects: trafilatura returns 41 chars → Firecrawl returns 4585 chars of clean project content.

## Design decisions (mirrors Claude Code WebFetch where applicable)
- **URL validation** at tool boundary — rejects non-http(s), credentials in URL, >2000 char URLs, hostnames without a dot
- **Cache** — 15-min TTL, in-memory dict (matches CC's `WebFetch` cache TTL)
- **Content cap** — 20,000 chars (5x `fetch_page`'s 4000, well under CC's 100K)
- **Timeout** — 30s (JS rendering is slower than static HTML)
- **Sync SDK wrapped via `asyncio.to_thread`** — SDK has built-in retry (3x exponential backoff), no tenacity needed
- **Error shape** — `{"error": "..."}` matching every other tool in the registry

## Test plan
- [x] 20 unit tests in `tests/test_firecrawl_scrape.py` (URL validation, execute, cache) — all pass
- [x] Full regression suite (683 tests) — pass
- [x] `ruff check` + `ruff format` — clean
- [x] Tool registration verified: 38 tools registered, `firecrawl_scrape` present
- [x] Real API smoke test: rosendin.com returns 4585 chars of clean markdown

## Follow-up PR
#TBD ships the `fetch_page` → `firecrawl_scrape` auto-fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web scraping tool powered by Firecrawl to extract content from URLs, returning structured data (url, text, length, source, status) with URL validation, caching, and automatic truncation.

* **Tests**
  * Added comprehensive test coverage validating URL rules, error handling, truncation, caching, and integration behaviors.

* **Chores**
  * Introduced a required Firecrawl SDK dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->