### PR TITLE
feat: add firecrawl fallback to fetch_page for JS-rendered pages

### DIFF
--- a/agent/src/tools/fetch_page.py
+++ b/agent/src/tools/fetch_page.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 import httpx
 import tenacity
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = 15.0  # seconds (raised from 10 for slow gov sites)
 _MAX_RETRIES = 2  # up to 3 total attempts
 _MAX_CHARS = 4000  # truncation limit
+_FIRECRAWL_FALLBACK_MIN_CHARS = 100
 _BLOCKED_CONTENT_TYPES = {"image/", "video/", "audio/", "application/zip"}
 _PDF_CONTENT_TYPE = "application/pdf"
 
@@ -82,6 +84,16 @@ def _extract_relevant_sections(text: str) -> str:
     return result
 
 
+async def _firecrawl_fallback(url: str) -> dict:
+    """Attempt Firecrawl scrape as fallback for JS-rendered pages."""
+    if not os.environ.get("FIRECRAWL_API_KEY"):
+        return {"error": "FIRECRAWL_API_KEY not set — cannot fall back to Firecrawl."}
+    from . import firecrawl_scrape
+
+    logger.info("fetch_page: trafilatura failed, falling back to Firecrawl for %s", url)
+    return await firecrawl_scrape.execute({"url": url})
+
+
 DEFINITION = {
     "name": "fetch_page",
     "description": (
@@ -91,7 +103,7 @@ DEFINITION = {
         "cuts off before naming the contractor. Returns cleaned text truncated to "
         "~4000 characters. Works on press releases, trade articles, EPC portfolio "
         "pages, news sites, AND PDF documents (regulatory filings, permits, etc.). "
-        "Will NOT work on pages that require JavaScript rendering."
+        "Automatically falls back to Firecrawl for JavaScript-rendered pages."
     ),
     "input_schema": {
         "type": "object",
@@ -152,8 +164,16 @@ async def execute(tool_input: dict) -> dict:
         no_fallback=False,
     )
 
-    if not text:
-        return {"error": "Could not extract article text from this page."}
+    # Firecrawl fallback: trafilatura returns None or very short text on
+    # JS-rendered pages (e.g. "Enable JavaScript and cookies to continue").
+    if not text or len(text) < _FIRECRAWL_FALLBACK_MIN_CHARS:
+        fallback = await _firecrawl_fallback(url)
+        if "error" not in fallback:
+            return fallback
+        # Both paths failed
+        if not text:
+            return {"error": "Could not extract article text from this page."}
+        # trafilatura returned something short — return it anyway
 
     if len(text) > _MAX_CHARS:
         text = _extract_relevant_sections(text)

--- a/agent/tests/test_fetch_page.py
+++ b/agent/tests/test_fetch_page.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from src.tools.fetch_page import _EPC_KEYWORDS, _MAX_CHARS, _extract_relevant_sections
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tools.fetch_page import (
+    _EPC_KEYWORDS,
+    _MAX_CHARS,
+    _extract_relevant_sections,
+)
+from src.tools.fetch_page import (
+    execute as fetch_page_execute,
+)
 
 
 class TestExtractRelevantSections:
@@ -103,3 +114,122 @@ class TestExtractRelevantSections:
         ]
         for name in expected:
             assert name in _EPC_KEYWORDS, f"{name} missing from _EPC_KEYWORDS"
+
+
+class TestFirecrawlFallback:
+    """Tests for the Firecrawl fallback behaviour in fetch_page.execute()."""
+
+    def _make_mock_response(self, html: str = "<html><body>content</body></html>"):
+        mock_response = AsyncMock()
+        mock_response.text = html
+        mock_response.content = b""
+        mock_response.headers = {"content-type": "text/html"}
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_firecrawl_when_trafilatura_returns_none(self):
+        """When trafilatura returns None, _firecrawl_fallback is called and its result returned."""
+        mock_response = self._make_mock_response()
+        fallback_result = {
+            "url": "https://example.com",
+            "text": "JS-rendered content",
+            "length": 19,
+        }
+
+        with (
+            patch("src.tools.fetch_page._fetch_with_retry", return_value=mock_response),
+            patch("trafilatura.extract", return_value=None),
+            patch(
+                "src.tools.fetch_page._firecrawl_fallback",
+                new_callable=AsyncMock,
+                return_value=fallback_result,
+            ) as mock_fallback,
+        ):
+            result = await fetch_page_execute({"url": "https://example.com"})
+
+        mock_fallback.assert_called_once_with("https://example.com")
+        assert result == fallback_result
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_trafilatura_returns_short_text(self):
+        """When trafilatura returns very short text (< 100 chars), fallback fires."""
+        mock_response = self._make_mock_response()
+        short_text = "Enable JavaScript and cookies to continue"  # 41 chars
+        fallback_result = {
+            "url": "https://example.com",
+            "text": "Real JS content here",
+            "length": 20,
+        }
+
+        with (
+            patch("src.tools.fetch_page._fetch_with_retry", return_value=mock_response),
+            patch("trafilatura.extract", return_value=short_text),
+            patch(
+                "src.tools.fetch_page._firecrawl_fallback",
+                new_callable=AsyncMock,
+                return_value=fallback_result,
+            ) as mock_fallback,
+        ):
+            result = await fetch_page_execute({"url": "https://example.com"})
+
+        mock_fallback.assert_called_once_with("https://example.com")
+        assert result == fallback_result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_both_trafilatura_and_firecrawl_fail(self):
+        """When both trafilatura and Firecrawl fail, an error dict is returned."""
+        mock_response = self._make_mock_response()
+        fallback_error = {"error": "Firecrawl API error: 403"}
+
+        with (
+            patch("src.tools.fetch_page._fetch_with_retry", return_value=mock_response),
+            patch("trafilatura.extract", return_value=None),
+            patch(
+                "src.tools.fetch_page._firecrawl_fallback",
+                new_callable=AsyncMock,
+                return_value=fallback_error,
+            ),
+        ):
+            result = await fetch_page_execute({"url": "https://example.com"})
+
+        assert "error" in result
+        assert "extract" in result["error"].lower() or "Could not" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_trafilatura_succeeds(self):
+        """When trafilatura returns sufficient text (>= 100 chars), fallback is NOT called."""
+        mock_response = self._make_mock_response()
+        long_text = "A" * 200  # well over 100 char threshold
+
+        with (
+            patch("src.tools.fetch_page._fetch_with_retry", return_value=mock_response),
+            patch("trafilatura.extract", return_value=long_text),
+            patch(
+                "src.tools.fetch_page._firecrawl_fallback",
+                new_callable=AsyncMock,
+            ) as mock_fallback,
+        ):
+            result = await fetch_page_execute({"url": "https://example.com"})
+
+        mock_fallback.assert_not_called()
+        assert "text" in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_firecrawl_key_missing(self):
+        """When trafilatura returns None and FIRECRAWL_API_KEY is missing, error is returned."""
+        mock_response = self._make_mock_response()
+        key_missing_error = {"error": "FIRECRAWL_API_KEY not set — cannot fall back to Firecrawl."}
+
+        with (
+            patch("src.tools.fetch_page._fetch_with_retry", return_value=mock_response),
+            patch("trafilatura.extract", return_value=None),
+            patch(
+                "src.tools.fetch_page._firecrawl_fallback",
+                new_callable=AsyncMock,
+                return_value=key_missing_error,
+            ),
+        ):
+            result = await fetch_page_execute({"url": "https://example.com"})
+
+        assert "error" in result


### PR DESCRIPTION
## Summary
- Wires `firecrawl_scrape` (from #28) as an automatic fallback in `fetch_page`
- Trigger: trafilatura returns `None` **or** `<100` chars (catches "Enable JavaScript" stub)
- Graceful degradation: if `FIRECRAWL_API_KEY` is not set, falls back to the original trafilatura error

## Why
Mirrors Claude Code's two-stage fetch pipeline: cheap/fast first (trafilatura), JS-capable second (Firecrawl). Agent keeps calling `fetch_page` as before; the tool now transparently handles JS pages.

**Cost-awareness:** Static pages (energy.gov, press releases) never trigger Firecrawl — confirmed via smoke test. Only pages where trafilatura fails pay the 1-credit cost.

## Changes
- `fetch_page.py`: added `_firecrawl_fallback()` helper + fallback call in `execute()` HTML path
- `fetch_page.py`: updated `DEFINITION.description` — removed "Will NOT work on pages that require JavaScript rendering"
- Constant: `_FIRECRAWL_FALLBACK_MIN_CHARS = 100`

## Test plan
- [x] 5 new tests in `TestFirecrawlFallback` cover: trigger on `None`, trigger on short text, both-failed path, no-fallback on success, no-fallback when key missing
- [x] All 14 `test_fetch_page.py` tests pass (9 pre-existing + 5 new)
- [x] Full regression suite (683 tests) — pass
- [x] `ruff check` + `ruff format` — clean
- [x] Smoke test: energy.gov → `source: trafilatura`, no Firecrawl credit spent (static path preserved)

## Depends on
#28 — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)